### PR TITLE
test(bench): add ML-DSA verify-throughput harness

### DIFF
--- a/bench/verify_throughput.rb
+++ b/bench/verify_throughput.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require "jwt"
+require "jwt/pq"
+
+ALG = "ML-DSA-65"
+PAYLOAD = { sub: "user-123", iat: 1_700_000_000, exp: 1_700_003_600 }.freeze
+FIXTURE = File.expand_path("fixtures/ml_dsa_65_sk.pem", __dir__)
+
+abort "Missing bench fixture: #{FIXTURE}" unless File.exist?(FIXTURE)
+key = JWT::PQ::Key.from_pem(File.read(FIXTURE))
+pub_key = JWT::PQ::Key.from_public_key(ALG, key.public_key)
+
+TOKEN = JWT.encode(PAYLOAD, key, ALG)
+
+100.times { JWT.decode(TOKEN, pub_key, true, algorithms: [ALG], verify_expiration: false) }
+
+report = Benchmark.ips(quiet: true) do |x|
+  x.config(time: 5, warmup: 2)
+  x.report("verify") { JWT.decode(TOKEN, pub_key, true, algorithms: [ALG], verify_expiration: false) }
+end
+
+entry = report.entries.first
+ips = entry.stats.central_tendency
+us_per_op = 1_000_000.0 / ips
+
+puts "METRIC verifies_per_sec=#{ips.round(2)}"
+puts "METRIC us_per_verify=#{us_per_op.round(2)}"


### PR DESCRIPTION
## Summary

Adds `bench/verify_throughput.rb`, a reproducible ML-DSA-65 verification benchmark driven by `benchmark-ips`. Reuses the fixed PEM key fixture from #3 and emits `METRIC verifies_per_sec=...` / `METRIC us_per_verify=...`.

Baseline captured on this commit: **7995 verifies/s (125.07 μs/verify)** on Ruby 3.4.6 + liboqs 0.15.0.

Infra foundation for the perf PR #6 — they are independent (each applies cleanly to `main`) but reviewing this one first makes the perf delta auditable.

## Test plan

- [ ] `bundle exec ruby bench/verify_throughput.rb` — emits METRIC lines, reproduces baseline ±noise