### PR TITLE
perf(verify): cache OQS_SIG handle, memoize pk buffer, inline JWA type-check

### DIFF
--- a/lib/jwt/pq/algorithms/ml_dsa.rb
+++ b/lib/jwt/pq/algorithms/ml_dsa.rb
@@ -20,8 +20,13 @@ module JWT
         end
 
         def verify(data:, signature:, verification_key:)
-          key = resolve_verification_key(verification_key)
-          key.verify(data, signature)
+          unless verification_key.is_a?(JWT::PQ::Key)
+            raise_verify_error!(
+              "Expected a JWT::PQ::Key, got #{verification_key.class}. " \
+              "Use JWT::PQ::Key.generate(:#{alg_symbol}) to create a key."
+            )
+          end
+          verification_key.verify(data, signature)
         rescue JWT::PQ::Error
           false
         end

--- a/lib/jwt/pq/key.rb
+++ b/lib/jwt/pq/key.rb
@@ -55,7 +55,7 @@ module JWT
 
       # Verify a signature using the public key.
       def verify(data, signature)
-        @ml_dsa.verify(data, signature, @public_key)
+        @ml_dsa.verify_with_pk_buffer(data, signature, pk_buffer)
       end
 
       # Whether this key can be used for signing.
@@ -157,6 +157,10 @@ module JWT
 
       def sk_buffer
         @sk_buffer ||= FFI::MemoryPointer.new(:uint8, @private_key.bytesize).put_bytes(0, @private_key)
+      end
+
+      def pk_buffer
+        @pk_buffer ||= FFI::MemoryPointer.new(:uint8, @public_key.bytesize).put_bytes(0, @public_key)
       end
 
       def resolve_algorithm(algorithm)

--- a/lib/jwt/pq/ml_dsa.rb
+++ b/lib/jwt/pq/ml_dsa.rb
@@ -25,6 +25,20 @@ module JWT
         end
       end
 
+      @verify_handles = {}
+      @verify_handles_mutex = Mutex.new
+
+      def self.verify_handle(algorithm)
+        @verify_handles[algorithm] || @verify_handles_mutex.synchronize do
+          @verify_handles[algorithm] ||= begin
+            h = LibOQS.OQS_SIG_new(algorithm)
+            raise LiboqsError, "Failed to initialize #{algorithm}" if h.null?
+
+            h
+          end
+        end
+      end
+
       attr_reader :algorithm
 
       def initialize(algorithm)
@@ -91,20 +105,24 @@ module JWT
       def verify(message, signature, public_key)
         validate_key_size!(public_key, :public_key)
 
-        sig = LibOQS.OQS_SIG_new(@algorithm)
-        raise LiboqsError, "Failed to initialize #{@algorithm}" if sig.null?
+        pk_buf = FFI::MemoryPointer.new(:uint8, public_key.bytesize)
+        pk_buf.put_bytes(0, public_key)
+        verify_with_pk_buffer(message, signature, pk_buf)
+      end
 
+      # Faster verify path: takes a pre-populated FFI::MemoryPointer holding
+      # the public key. Caller is responsible for buffer lifecycle. Used by
+      # JWT::PQ::Key to avoid re-allocating+copying the public key on every
+      # verify call.
+      def verify_with_pk_buffer(message, signature, pk_buf)
+        sig = self.class.verify_handle(@algorithm)
         msg_buf = FFI::MemoryPointer.from_string(message)
         sig_buf = FFI::MemoryPointer.new(:uint8, signature.bytesize)
         sig_buf.put_bytes(0, signature)
-        pk_buf = FFI::MemoryPointer.new(:uint8, public_key.bytesize)
-        pk_buf.put_bytes(0, public_key)
 
         status = LibOQS.OQS_SIG_verify(sig, msg_buf, message.bytesize,
                                        sig_buf, signature.bytesize, pk_buf)
         status == LibOQS::OQS_SUCCESS
-      ensure
-        LibOQS.OQS_SIG_free(sig) if sig && !sig.null?
       end
 
       # Key sizes for this algorithm


### PR DESCRIPTION
## Summary

Three verify-path optimizations for `JWT::PQ::Key#verify`, symmetric to the sign optimizations merged in #4:

1. **Class-level cache of `OQS_SIG` handle per algorithm** (`MlDsa.verify_handle`). Skips `OQS_SIG_new` / `OQS_SIG_free` on every verify. Thread-safe via Mutex on init. +3.58%.
2. **Per-Key memoization of the public-key FFI buffer.** Mirrors the `sk_buffer` pattern from #4. Avoids a 1952B FFI alloc + `put_bytes` per verify. +8.68% on top of previous.
3. **Inline type-check in `JWA::Algorithms::MlDsa#verify`.** Skip the `resolve_verification_key` method dispatch per verify. +6.08% on top of previous.

Cumulative: **7995 → 9548 verifies/s (+19.42%)**.

## Numbers

Measured with the harness introduced in #5 (5s measure + 2s warmup, `benchmark-ips`, fixed public key + fixed token):

|                        | verifies/s | μs/verify | vs baseline |
|------------------------|-----------:|----------:|-------------|
| Baseline               |    7995.38 |    125.07 |           — |
| + verify handle cache  |    8281.75 |    120.75 |      +3.58% |
| + pk FFI buffer memo   |    9000.73 |    111.10 |     +12.58% |
| + JWA type-check inline|    9548.35 |    104.73 |     +19.42% |

Raw `OQS_SIG_verify` ceiling (pre-allocated buffers, no `JWT.decode`): **20767 verifies/s**. `Key#verify` direct (no `JWT.decode`): **19182 verifies/s (93% of raw)**. Our `JWT.decode`-path best is 46% of raw — the remaining ~53 μs gap lives inside `ruby-jwt` (JSON parse + base64url decode + orchestration) and is out of scope for this session.

Confidence (per autoresearch MAD over 4+ runs): **3.09×** above session noise floor.

## Discarded ideas

- `@verify_handle ||= ...` ivar cache on Key with inlined FFI: flat (-0.08%), added complexity.
- Per-Key sig FFI buffer memoization (re-put_bytes per call): regressed -9.25%. Same pattern confirmed in the sign session — caching FFI buffers that are mutated per call regresses on this stack (macOS x86_64 + ffi gem + Ruby 3.4). Only caching input-only, write-once buffers (sk_buffer, pk_buffer) wins.

## Test plan

- [ ] `bundle exec rspec` — full suite + ACVP KATs green (218+3 examples in main)
- [ ] Tampered signature / message / wrong public key still produce `false` (existing specs cover)
- [ ] Concurrent verification from multiple threads on the same `Key` still works — `@verify_handles` hash uses Mutex on init; `OQS_SIG` descriptors are read-only after init; `pk_buffer` is read-only after populate
- [ ] `bundle exec ruby bench/verify_throughput.rb` (needs #5) reproduces ~9500 verifies/s on comparable hardware

## Notes for reviewer

- `MlDsa.verify_handle` and `MlDsa.sign_handle` (from #4) are deliberately separate class-instance hashes — could be unified later, but keeping them independent avoids risk of cross-path regression.
- `MlDsa#verify(message, signature, public_key)` (old bytes-in API) is unchanged; the fast path goes through a new `MlDsa#verify_with_pk_buffer(message, signature, pk_buf)` that `Key#verify` uses directly.
- `Key#pk_buffer` is public-data-only; no `destroy!` wiring needed (public keys are not secret), but the buffer is held for the Key's lifetime.