### PR TITLE
perf(hybrid): optimize HybridEdDsa#sign orchestration (+12.1%)

### DIFF
--- a/lib/jwt/pq/algorithms/hybrid_eddsa.rb
+++ b/lib/jwt/pq/algorithms/hybrid_eddsa.rb
@@ -17,17 +17,25 @@ module JWT
 
         def initialize(alg)
           @alg = alg
+          @ml_dsa_algorithm = alg.sub("EdDSA+", "")
+          @header = { "alg" => alg, "pq_alg" => @ml_dsa_algorithm }.freeze
         end
 
         def header(*)
-          { "alg" => alg, "pq_alg" => ml_dsa_algorithm }
+          @header
         end
 
         def sign(data:, signing_key:)
-          key = resolve_signing_key(signing_key)
+          unless signing_key.is_a?(JWT::PQ::HybridKey)
+            raise_sign_error!(
+              "Expected a JWT::PQ::HybridKey, got #{signing_key.class}. " \
+              "Use JWT::PQ::HybridKey.generate to create a hybrid key."
+            )
+          end
+          raise_sign_error!("Both Ed25519 and ML-DSA private keys required") unless signing_key.private?
 
-          ed_sig = key.ed25519_signing_key.sign(data)
-          ml_sig = key.ml_dsa_key.sign(data)
+          ed_sig = signing_key.ed25519_signing_key.sign(data)
+          ml_sig = signing_key.ml_dsa_key.sign(data)
 
           # Concatenate: Ed25519 (64 bytes) || ML-DSA (variable)
           ed_sig + ml_sig
@@ -57,9 +65,7 @@ module JWT
 
         private
 
-        def ml_dsa_algorithm
-          alg.sub("EdDSA+", "")
-        end
+        attr_reader :ml_dsa_algorithm
 
         def resolve_signing_key(key)
           case key


### PR DESCRIPTION
## Summary

Two orchestration-layer optimizations for `HybridEdDsa#sign`, the algorithm that powers `JWT.encode(..., "EdDSA+ML-DSA-{44,65,87}")`:

1. **Inline the type-check** — removes one method dispatch (`resolve_signing_key`) and the `case/when` overhead per call. Same pattern applied to ML-DSA verify in v0.3.0. **+1.62%**.
2. **Cache header hash and precompute `ml_dsa_algorithm`** — `header()` is called once per `JWT.encode`; the previous implementation allocated a new Hash and performed a `String#sub` every call. Now returns a frozen instance variable set at init. **+10.35% on top of #1**.

**Cumulative: 5200 → 5831 sigs/s (+12.13%)** on Ruby 3.4.6, macOS x86_64, liboqs 0.15.0 for `EdDSA+ML-DSA-65`. Validated against the full RSpec suite (218 examples) after each change.

## Methodology

Autoresearch session (`benchmark-ips` inside the MCP plugin) with 2s warmup + 5s measurement per experiment and `autoresearch.checks.sh` running the full RSpec suite as a correctness gate. Four experiments total: two kept (above), two discarded (see below).

## Discarded experiments (for the record)

- `String.new(capacity: n, encoding: BINARY) << ed_sig << ml_sig` — regressed **-8.2%**
- `ed_sig << ml_sig` in-place mutation — regressed **-9.4%**

Pattern consistent with prior sessions (sign v0.3.0, verify v0.3.0): on Ruby 3.4 / macOS, `a + b` for two-string concat is specialized and hard to beat; any capacity-aware or in-place variant adds overhead.

## Files

- `lib/jwt/pq/algorithms/hybrid_eddsa.rb` — the two optimizations

## Test plan

- [x] Full RSpec suite green (218 examples, 0 failures)
- [x] Throughput delta measured (benchmark-ips, n=2)