### PR TITLE
bench(hybrid): add EdDSA+ML-DSA-65 verify throughput harness

### DIFF
--- a/bench/hybrid_verify_throughput.rb
+++ b/bench/hybrid_verify_throughput.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require "jwt"
+require "jwt/pq"
+require "ed25519"
+
+ALG = "EdDSA+ML-DSA-65"
+PAYLOAD = { sub: "user-123", iat: 1_700_000_000, exp: 1_700_003_600 }.freeze
+ML_DSA_FIXTURE = File.expand_path("fixtures/ml_dsa_65_sk.pem", __dir__)
+ED_SEED_FIXTURE = File.expand_path("fixtures/ed25519_seed.bin", __dir__)
+
+abort "Missing bench fixture: #{ML_DSA_FIXTURE}" unless File.exist?(ML_DSA_FIXTURE)
+abort "Missing bench fixture: #{ED_SEED_FIXTURE}" unless File.exist?(ED_SEED_FIXTURE)
+
+ml_key = JWT::PQ::Key.from_pem(File.read(ML_DSA_FIXTURE))
+ed_key = Ed25519::SigningKey.new(File.binread(ED_SEED_FIXTURE))
+hybrid = JWT::PQ::HybridKey.new(ed25519: ed_key, ml_dsa: ml_key)
+
+TOKEN = JWT.encode(PAYLOAD, hybrid, ALG)
+
+100.times { JWT.decode(TOKEN, hybrid, true, algorithms: [ALG], verify_expiration: false) }
+
+report = Benchmark.ips(quiet: true) do |x|
+  x.config(time: 5, warmup: 2)
+  x.report("hybrid_verify") { JWT.decode(TOKEN, hybrid, true, algorithms: [ALG], verify_expiration: false) }
+end
+
+entry = report.entries.first
+ips = entry.stats.central_tendency
+us_per_op = 1_000_000.0 / ips
+
+puts "METRIC algorithm=#{ALG}"
+puts "METRIC verifies_per_sec=#{ips.round(2)}"
+puts "METRIC us_per_verify=#{us_per_op.round(2)}"


### PR DESCRIPTION
## Summary

Symmetric counterpart to the hybrid sign bench harness — benchmarks `JWT.decode(token, hybrid_key, true, algorithms: ["EdDSA+ML-DSA-65"])` via `benchmark-ips`, using a fixed Ed25519 seed + the existing ML-DSA-65 PEM for reproducibility.

Emits `METRIC verifies_per_sec / us_per_verify`.

Baseline on main (Ruby 3.4.6, macOS, liboqs 0.15.0): **4812 verifies/s** (207.8 µs/op). A +2.31% orchestration-layer optimization is in a sibling PR.

> Note: `bench/fixtures/ed25519_seed.bin` is also added by the hybrid-sign bench PR (#8). If both merge in sequence, GitHub will flag a conflict on the seed — pick either; both are 32-byte random values used only for bench reproducibility.

## Files

- `bench/hybrid_verify_throughput.rb`
- `bench/fixtures/ed25519_seed.bin`

## Test plan

- [x] `bundle exec ruby bench/hybrid_verify_throughput.rb` runs without error
- [x] Full RSpec suite green