### PR TITLE
docs: README expansion + SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,52 @@ The hybrid algorithms (`EdDSA+ML-DSA-{44,65,87}`) provide defense-in-depth: if e
 
 The `alg` header values follow a `ClassicAlg+PQAlg` convention. The IETF draft `draft-ietf-cose-dilithium` is still evolving — these values may change in future versions to align with the final standard.
 
+## Correctness
+
+- **NIST ACVP known-answer tests.** `spec/jwt/pq/kat_spec.rb` runs the full sigVer KAT subset shipped with liboqs against `JWT::PQ::Key#verify` for ML-DSA-44/65/87, covering both positive and negative cases. These vectors are executed in CI on every push. (sigGen KATs are not used because FIPS 204 specifies hedged signing with internal randomness, which makes signature output non-deterministic.)
+- **Cross-language interop.** The [`Cross-interop`](https://github.com/marcelopazzo/jwt-pq/actions/workflows/interop.yml) workflow signs with `jwt-pq` and verifies with [`dilithium-py`](https://pypi.org/project/dilithium-py/), and vice versa, for all three parameter sets. It runs on every push and weekly on `cron`.
+
+## Performance
+
+Measured with `bench/sign_throughput.rb` / `bench/verify_throughput.rb` (and the hybrid variants) using `benchmark-ips`. Hardware: Intel Core i9-9880H @ 2.30 GHz, macOS, Ruby 3.4.6, bundled liboqs 0.15.0, single-threaded.
+
+| Algorithm | Sign | Verify |
+|---|---|---|
+| ML-DSA-44 | 8,026 ops/s (125 µs) | 11,074 ops/s (90 µs) |
+| ML-DSA-65 | 5,972 ops/s (167 µs) | 9,339 ops/s (107 µs) |
+| ML-DSA-87 | 4,911 ops/s (204 µs) | 6,471 ops/s (155 µs) |
+| EdDSA+ML-DSA-65 | 4,695 ops/s (213 µs) | 3,924 ops/s (255 µs) |
+
+Numbers are illustrative — rerun `bundle exec ruby bench/sign_throughput.rb` on your target hardware before capacity-planning. ML-DSA is ~1–2 orders of magnitude slower than Ed25519 (~70 k sigs/s on the same box); plan accordingly.
+
+## Backends
+
+ML-DSA operations are delegated to [liboqs](https://github.com/open-quantum-safe/liboqs), bundled and compiled during `gem install`. An alternative OpenSSL 3.5+ backend is tracked in [#14](https://github.com/marcelopazzo/jwt-pq/issues/14) and will be added once OpenSSL 3.5 ships widely in distros.
+
+## Specification tracking
+
+jwt-pq targets the current IETF drafts for JOSE/COSE post-quantum signatures. The tracked drafts are:
+
+- [`draft-ietf-cose-dilithium`](https://datatracker.ietf.org/doc/draft-ietf-cose-dilithium/) — ML-DSA in JOSE/COSE, including the `AKP` key type
+- [`draft-ietf-jose-fully-specified-algorithms`](https://datatracker.ietf.org/doc/draft-ietf-jose-fully-specified-algorithms/) — fully specified algorithm identifiers
+- [`FIPS 204`](https://csrc.nist.gov/pubs/fips/204/final) — ML-DSA itself
+
+Because these drafts are still pre-RFC, the JWK `kty`/`alg` values, header registration, and hybrid concatenation format may change between jwt-pq minor releases. Breaking changes will be called out in [CHANGELOG.md](CHANGELOG.md) and bump the minor version pre-1.0 (or the major version post-1.0).
+
+## Thread safety
+
+- `JWT::PQ::Key` and `JWT::PQ::HybridKey` are safe to share across threads for **verification**. The underlying `OQS_SIG` verify context is process-global and reused; verify itself is stateless at the liboqs level.
+- **Signing** from multiple threads with the *same* `Key` instance is also safe in practice (liboqs ML-DSA sign does not mutate context state), but if you want the strongest guarantee, give each thread its own `Key` and use `destroy!` when done.
+- `destroy!` mutates the receiver — do not call it concurrently with `#sign` / `#verify`.
+
+## Algorithm registration
+
+`require "jwt/pq"` registers `ML-DSA-{44,65,87}` and `EdDSA+ML-DSA-{44,65,87}` with ruby-jwt via the **public** `JWT::JWA::SigningAlgorithm.register_algorithm` API — this is not a monkey-patch. The registration is idempotent and coexists with other custom algorithms (e.g. `jwt-eddsa`). Load order between `jwt` and `jwt/pq` does not matter.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for the supported-versions policy, vulnerability reporting process, and how upstream liboqs advisories are handled.
+
 ## Development
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security Policy
+
+## Supported versions
+
+jwt-pq is pre-1.0. Only the latest minor release receives security fixes.
+
+| Version | Supported |
+|---------|-----------|
+| 0.4.x   | Yes       |
+| < 0.4   | No        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security problems.
+
+Report privately via GitHub's [private vulnerability reporting](https://github.com/marcelopazzo/jwt-pq/security/advisories/new) or by email to `security@marcelopazzo.com`.
+
+Include:
+
+- Affected version(s)
+- Reproduction steps or proof of concept
+- Impact assessment (key recovery, signature forgery, denial of service, etc.)
+
+You should receive an acknowledgement within **72 hours**. A fix or mitigation plan will follow within **14 days** for high-severity issues.
+
+## Scope
+
+In scope:
+
+- Signature forgery, key recovery, or authentication bypass in `JWT::PQ::Key`, `JWT::PQ::HybridKey`, or the JWT algorithm adapters
+- JWK/PEM parsers accepting malformed input in a way that leaks private key material or enables forgery
+- Memory safety issues in the FFI layer (e.g. out-of-bounds reads through user-controlled inputs)
+
+Out of scope (report upstream):
+
+- Vulnerabilities in [liboqs](https://github.com/open-quantum-safe/liboqs) itself — report to the liboqs maintainers
+- Vulnerabilities in [ruby-jwt](https://github.com/jwt/ruby-jwt), [ed25519](https://github.com/RubyCrypto/ed25519), or [pqc_asn1](https://github.com/msuliq/pqc_asn1) — report to those projects
+
+## Upstream liboqs advisories
+
+jwt-pq bundles a pinned version of liboqs (see `LIBOQS_VERSION` in `ext/jwt/pq/extconf.rb`, currently **0.15.0**, integrity-checked against a SHA-256 of the source tarball).
+
+When [liboqs](https://github.com/open-quantum-safe/liboqs/security/advisories) publishes a security advisory affecting an algorithm we ship:
+
+1. A patch release of jwt-pq will bump `LIBOQS_VERSION` to the fixed upstream version.
+2. The release will be cut within **7 days** of the liboqs advisory for high-severity issues, **30 days** for medium/low.
+3. The changelog entry and GitHub Release notes will link to the upstream advisory.
+
+Users running with `--use-system-libraries` are responsible for upgrading the system liboqs themselves.
+
+## Cryptographic notes
+
+- ML-DSA operations (keygen, sign, verify) are delegated to liboqs in C. jwt-pq does not reimplement the algorithm.
+- Private key material is wiped via `#destroy!` on `JWT::PQ::Key` / `JWT::PQ::HybridKey`, and during PEM import via `PqcAsn1::SecureBuffer`.
+- jwt-pq does not perform manual constant-time comparisons on signatures or MACs — signature verification returns a boolean from liboqs, and there are no equality checks on key/signature bytes in the Ruby layer.
+- Randomness for keygen and signing is sourced from liboqs' internal RNG (which uses the system CSPRNG).


### PR DESCRIPTION
## Summary

- Expand README with Correctness (ACVP + cross-interop), Performance (benched throughput), Backends, Specification tracking, Thread safety, and Algorithm registration sections.
- Clarify that algorithm registration uses ruby-jwt's public `register_algorithm` API (not a monkey-patch).
- Add `SECURITY.md` with private disclosure channel, supported-versions policy, and an SLA for republishing the gem on upstream liboqs advisories.

Relates to #14 (OpenSSL 3.5+ backend tracking, linked from the new Backends section).

## Test plan

- [x] Benchmarks rerun sequentially on Intel i9-9880H / Ruby 3.4.6 to capture the numbers in the README table
- [x] Constant-time audit: confirmed no `==` over signature/key bytes in `lib/` (noted in SECURITY.md)
- [x] CI green on this PR