### PR TITLE
test: restore coverage to 100% line after perf-inlining cleanup

### DIFF
--- a/lib/jwt/pq/algorithms/hybrid_eddsa.rb
+++ b/lib/jwt/pq/algorithms/hybrid_eddsa.rb
@@ -63,36 +63,10 @@ module JWT
           ml_valid = verification_key.ml_dsa_key.verify(data, ml_sig)
 
           ed_valid && ml_valid
+        # :nocov: — defensive rescue; Key#verify returns bool, does not raise PQ::Error in practice
         rescue JWT::PQ::Error
           false
-        end
-
-        private
-
-        attr_reader :ml_dsa_algorithm
-
-        def resolve_signing_key(key)
-          case key
-          when JWT::PQ::HybridKey
-            raise_sign_error!("Both Ed25519 and ML-DSA private keys required") unless key.private?
-            key
-          else
-            raise_sign_error!(
-              "Expected a JWT::PQ::HybridKey, got #{key.class}. " \
-              "Use JWT::PQ::HybridKey.generate to create a hybrid key."
-            )
-          end
-        end
-
-        def resolve_verification_key(key)
-          case key
-          when JWT::PQ::HybridKey
-            key
-          else
-            raise_verify_error!(
-              "Expected a JWT::PQ::HybridKey, got #{key.class}."
-            )
-          end
+          # :nocov:
         end
 
         register_algorithm(new("EdDSA+ML-DSA-44"))

--- a/lib/jwt/pq/algorithms/ml_dsa.rb
+++ b/lib/jwt/pq/algorithms/ml_dsa.rb
@@ -27,8 +27,10 @@ module JWT
             )
           end
           verification_key.verify(data, signature)
+        # :nocov: — defensive rescue; Key#verify returns bool, does not raise PQ::Error in practice
         rescue JWT::PQ::Error
           false
+          # :nocov:
         end
 
         private
@@ -40,18 +42,6 @@ module JWT
             key
           else
             raise_sign_error!(
-              "Expected a JWT::PQ::Key, got #{key.class}. " \
-              "Use JWT::PQ::Key.generate(:#{alg_symbol}) to create a key."
-            )
-          end
-        end
-
-        def resolve_verification_key(key)
-          case key
-          when JWT::PQ::Key
-            key
-          else
-            raise_verify_error!(
               "Expected a JWT::PQ::Key, got #{key.class}. " \
               "Use JWT::PQ::Key.generate(:#{alg_symbol}) to create a key."
             )

--- a/lib/jwt/pq/key.rb
+++ b/lib/jwt/pq/key.rb
@@ -88,7 +88,9 @@ module JWT
         case info.format
         when :spki  then new(algorithm: alg_name, public_key: info.key)
         when :pkcs8 then build_from_pkcs8(info, alg_name)
+        # :nocov: — defensive guard; PqcAsn1::DER.parse_pem only returns :spki or :pkcs8
         else raise KeyError, "Unsupported PEM format: #{info.format}"
+          # :nocov:
         end
       ensure
         info&.key&.wipe! if info&.format == :pkcs8

--- a/lib/jwt/pq/liboqs.rb
+++ b/lib/jwt/pq/liboqs.rb
@@ -40,12 +40,14 @@ module JWT
       begin
         ffi_lib lib_path
       rescue LoadError => e
+        # :nocov: — reached only when liboqs is missing at module load
         raise JWT::PQ::LiboqsError,
               "liboqs not found. The vendored library may not have been compiled " \
               "during gem install. Ensure cmake and a C compiler are installed, " \
               "then reinstall: gem install jwt-pq. Alternatively, install liboqs " \
               "manually and set OQS_LIB to the full path. " \
               "Original error: #{e.message}"
+        # :nocov:
       end
 
       # OQS_SIG *OQS_SIG_new(const char *method_name)

--- a/spec/jwt/pq/hybrid_key_spec.rb
+++ b/spec/jwt/pq/hybrid_key_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe JWT::PQ::HybridKey do
         expect(key.hybrid_algorithm).to eq("EdDSA+#{alg_name}")
       end
     end
+
+    it "raises MissingDependencyError when ed25519 is not available" do
+      allow(described_class).to receive(:require).with("ed25519").and_raise(LoadError)
+      expect { described_class.generate }.to raise_error(JWT::PQ::MissingDependencyError, /jwt-eddsa/)
+    end
   end
 
   describe ".new" do

--- a/spec/jwt/pq/liboqs_spec.rb
+++ b/spec/jwt/pq/liboqs_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe JWT::PQ::LibOQS do
+  describe ".lib_path" do
+    around do |example|
+      original = ENV.delete("OQS_LIB")
+      example.run
+    ensure
+      ENV["OQS_LIB"] = original if original
+    end
+
+    it "returns OQS_LIB when set" do
+      ENV["OQS_LIB"] = "/custom/liboqs.dylib"
+      expect(described_class.lib_path).to eq("/custom/liboqs.dylib")
+    end
+
+    it "returns the vendored path when present" do
+      allow(described_class).to receive(:vendored_lib_path).and_return("/vendored/liboqs.dylib")
+      expect(described_class.lib_path).to eq("/vendored/liboqs.dylib")
+    end
+
+    it "falls back to the system library name" do
+      allow(described_class).to receive(:vendored_lib_path).and_return(nil)
+      expect(described_class.lib_path).to eq("oqs")
+    end
+  end
+
+  describe ".vendored_lib_path" do
+    it "returns nil when no vendored library exists" do
+      allow(File).to receive(:exist?).and_return(false)
+      expect(described_class.send(:vendored_lib_path)).to be_nil
+    end
+
+    it "returns the dylib path when present" do
+      allow(File).to receive(:exist?) do |path|
+        path.end_with?("liboqs.dylib")
+      end
+      expect(described_class.send(:vendored_lib_path)).to end_with("liboqs.dylib")
+    end
+  end
+end

--- a/spec/jwt/pq_spec.rb
+++ b/spec/jwt/pq_spec.rb
@@ -5,5 +5,10 @@ RSpec.describe JWT::PQ do
     it "returns true when ed25519 is available" do
       expect(described_class.hybrid_available?).to be true
     end
+
+    it "returns false when ed25519 cannot be required" do
+      allow(described_class).to receive(:require).with("ed25519").and_raise(LoadError)
+      expect(described_class.hybrid_available?).to be false
+    end
   end
 end


### PR DESCRIPTION
## Summary

Codecov dropped on the `algorithms/` tree after PRs #9 (sign-side inlining) and #12 (verify-side inlining). Root cause: those PRs replaced `resolve_signing_key` / `resolve_verification_key` dispatch with inline `is_a?` checks, leaving the original private resolver methods as dead code.

### Changes

- Remove dead code:
  - `HybridEdDsa#resolve_signing_key`, `#resolve_verification_key`, `attr_reader :ml_dsa_algorithm`
  - `MlDsa#resolve_verification_key`
- Add specs for:
  - `JWT::PQ.hybrid_available?` rescue path
  - `JWT::PQ::LibOQS.lib_path` (env var, vendored, system fallback) and `.vendored_lib_path`
  - `JWT::PQ::HybridKey.generate` missing-dependency path
- `:nocov:` four unreachable-by-design branches: liboqs load failure, unsupported PEM format else-raise, `rescue JWT::PQ::Error` defensive returns

### Coverage

| | Before | After |
|---|---|---|
| Line | 95.29% | **100.0%** (363/363) |
| Branch | 76.42% | **86.6%** (84/97) |

### Performance (no regression)

Median of 3 sequential runs on Intel i9-9880H / Ruby 3.4.6:

| Algorithm | Sign | Verify |
|---|---|---|
| ML-DSA-65 | 6643 sigs/s | 10023 verifies/s |
| EdDSA+ML-DSA-65 | 5327 sigs/s | 4552 verifies/s |

The `@ml_dsa_algorithm` ivar cache (the actual perf win from PR #9) is preserved. Only the never-called `attr_reader` was removed.

## Test plan

- [x] `bundle exec rspec` — 224 examples, 0 failures
- [x] `bundle exec rubocop` — clean
- [x] Benches rerun sequentially, no regression
- [x] CI green