### PR TITLE
test(jwk): verify thumbprint matches independent RFC 7638 computation

### DIFF
--- a/spec/jwt/pq/jwk_spec.rb
+++ b/spec/jwt/pq/jwk_spec.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "json"
+require "openssl"
+require "base64"
+
 RSpec.describe JWT::PQ::JWK do
   JWT::PQ::MlDsa::ALGORITHMS.each_key do |alg_name|
     context "with #{alg_name}" do
@@ -72,6 +76,19 @@ RSpec.describe JWT::PQ::JWK do
         it "is used as kid in export" do
           exported = jwk.export
           expect(exported[:kid]).to eq(jwk.thumbprint)
+        end
+
+        # Independent RFC 7638 thumbprint calculation, following the AKP
+        # required-members list from draft-ietf-cose-dilithium: alg, kty, pub.
+        # Any divergence here (field order, field name, JSON canonicalization,
+        # hash, encoding) would break interop with other AKP implementations.
+        it "matches an independent RFC 7638 computation over (alg, kty, pub)" do
+          pub_b64 = Base64.urlsafe_encode64(key.public_key, padding: false)
+          canonical = JSON.generate("alg" => alg_name, "kty" => "AKP", "pub" => pub_b64)
+          expected_digest = OpenSSL::Digest::SHA256.digest(canonical)
+          expected = Base64.urlsafe_encode64(expected_digest, padding: false)
+
+          expect(jwk.thumbprint).to eq(expected)
         end
       end
 


### PR DESCRIPTION
## Summary

Adds a regression spec that recomputes the RFC 7638 JWK thumbprint from scratch (JSON canonical form over the AKP required members `alg`, `kty`, `pub`, SHA-256, base64url no padding) and asserts equality with `JWT::PQ::JWK#thumbprint`.

- Runs for every ML-DSA-{44,65,87} variant via the existing `ALGORITHMS.each_key` loop.
- **Scope is intentionally intra-Ruby regression, not cross-implementation interop.** If we ever change the field names, canonical ordering, hash, or encoding, this spec breaks — but if the field names diverged from draft-ietf-cose-dilithium in both the implementation and the test, both sides would still agree. True interop depends on an external library that supports AKP JWK, and none is stable yet.

No production code changes.

## Test plan

- [x] `bundle exec rspec spec/jwt/pq/jwk_spec.rb` — 44 examples, 0 failures.