### PR TITLE
test(interop): Ruby→Python JWK cross-interop

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -71,3 +71,33 @@ jobs:
 
       - name: Ruby verifies
         run: bundle exec ruby spec/interop/ruby_verify.rb interop_out
+
+  ruby-jwk-python-verify:
+    name: Ruby exports JWK + signs → Python parses JWK + verifies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build
+
+      - uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Compile vendored liboqs
+        run: bundle exec rake compile
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dilithium-py
+        run: pip install "dilithium-py==1.4.0"
+
+      - name: Ruby exports JWK + signs
+        run: bundle exec ruby spec/interop/ruby_jwk_sign.rb interop_out
+
+      - name: Python parses JWK + verifies
+        run: python spec/interop/python_jwk_verify.py interop_out

--- a/spec/interop/python_jwk_verify.py
+++ b/spec/interop/python_jwk_verify.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Parse a jwt-pq JWK (kty=AKP) and verify an ML-DSA-65 signature with dilithium-py.
+
+This exercises the JWK wire format end-to-end: base64url decoding of the
+`pub` field, kty/alg field names, and that the bytes actually round-trip
+to a Dilithium public key that the reference implementation can use.
+"""
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+from dilithium_py.ml_dsa import ML_DSA_65
+
+in_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "interop_out")
+
+jwk = json.loads((in_dir / "jwk.json").read_text())
+msg = (in_dir / "jwk_msg.bin").read_bytes()
+sig = (in_dir / "jwk_sig.bin").read_bytes()
+
+if jwk.get("kty") != "AKP":
+    print(f"FAIL: expected kty=AKP, got kty={jwk.get('kty')!r}")
+    sys.exit(1)
+
+if jwk.get("alg") != "ML-DSA-65":
+    print(f"FAIL: expected alg=ML-DSA-65, got alg={jwk.get('alg')!r}")
+    sys.exit(1)
+
+if "pub" not in jwk:
+    print("FAIL: JWK is missing 'pub' field")
+    sys.exit(1)
+
+
+def b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+pk = b64url_decode(jwk["pub"])
+
+print(f"Python verifying Ruby-produced ML-DSA-65 signature via JWK")
+print(f"  kty={jwk['kty']} alg={jwk['alg']} kid={jwk.get('kid', '<none>')}")
+print(f"  pk:  {len(pk)} bytes (decoded from JWK pub field)")
+print(f"  msg: {len(msg)} bytes")
+print(f"  sig: {len(sig)} bytes")
+
+if len(pk) != 1952:
+    print(f"FAIL: ML-DSA-65 public key must be 1952 bytes, got {len(pk)}")
+    sys.exit(1)
+
+ok = ML_DSA_65.verify(pk, msg, sig)
+if not ok:
+    print("FAIL: dilithium-py rejected the signature")
+    sys.exit(1)
+
+print("PASS: Python verified Ruby JWK-exported key + signature")

--- a/spec/interop/ruby_jwk_sign.rb
+++ b/spec/interop/ruby_jwk_sign.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Generate an ML-DSA-65 keypair with jwt-pq, export it as a JWK
+# (draft-ietf-cose-dilithium / kty=AKP), sign a fixed message, and
+# write jwk.json + msg + sig for Python to verify after parsing the JWK.
+
+require "jwt/pq"
+require "fileutils"
+require "json"
+
+out_dir = ARGV[0] || "interop_out"
+FileUtils.mkdir_p(out_dir)
+
+message = "jwt-pq cross-interop JWK test message"
+
+key = JWT::PQ::Key.generate(:ml_dsa_65)
+signature = key.sign(message)
+jwk = JWT::PQ::JWK.new(key).export
+
+File.write(File.join(out_dir, "jwk.json"), JSON.pretty_generate(jwk))
+File.binwrite(File.join(out_dir, "jwk_msg.bin"), message)
+File.binwrite(File.join(out_dir, "jwk_sig.bin"), signature)
+
+puts "Ruby exported ML-DSA-65 JWK and signed #{message.bytesize}-byte message"
+puts "  jwk kty=#{jwk[:kty]} alg=#{jwk[:alg]} pub=#{jwk[:pub].bytesize} chars kid=#{jwk[:kid]}"
+puts "  sig: #{signature.bytesize} bytes"
+puts "  out: #{out_dir}/"
+
+raise "self-verify failed" unless key.verify(message, signature)
+
+puts "Ruby self-verify: OK"


### PR DESCRIPTION
## Summary

Adds a new CI job that exercises the JWK wire format end-to-end between jwt-pq (Ruby) and dilithium-py (Python):

1. Ruby generates an ML-DSA-65 keypair, exports it as a JWK (kty=AKP per draft-ietf-cose-dilithium), signs a fixed message, and writes `jwk.json` + `jwk_msg.bin` + `jwk_sig.bin`.
2. Python parses the JWK, asserts `kty=AKP` and `alg=ML-DSA-65`, base64url-decodes the `pub` field, and verifies the signature with `ML_DSA_65.verify` from `dilithium-py==1.4.0`.

If AKP field names, base64url canonicalization, or the public-key byte layout ever drift from the spec, the Python step fails and interop is flagged loudly.

The existing raw-bytes Ruby↔Python interop jobs are unchanged; this new job is additive (third job in `.github/workflows/interop.yml`).

## Test plan

- [x] Ruby half sanity-checked locally: `bundle exec ruby spec/interop/ruby_jwk_sign.rb /tmp/jwk_interop_test` → writes the three artefacts and self-verifies.
- [x] CI `ruby-jwk-python-verify` job passes.