### PR TITLE
docs(yard): document public API surface with YARD tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
         if: matrix.ruby == '3.4' && matrix.os == 'ubuntu-latest'
         run: bundle exec rubocop
 
+      - name: Validate YARD docs
+        if: matrix.ruby == '3.4' && matrix.os == 'ubuntu-latest'
+        run: bundle exec yard doc --no-output --fail-on-warning
+
   test-system-libraries:
     runs-on: ubuntu-latest
     steps:

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--markup markdown
+--readme README.md
+--files CHANGELOG.md,SECURITY.md
+--output-dir doc
+--no-private
+--protected
+lib/**/*.rb
+-
+LICENSE

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem "rspec", "~> 3.13"
   gem "rubocop", "~> 1.75"
   gem "rubocop-rspec", "~> 3.0"
+  gem "yard", "~> 0.9"
 end
 
 group :test do

--- a/lib/jwt/pq.rb
+++ b/lib/jwt/pq.rb
@@ -11,8 +11,29 @@ require_relative "pq/hybrid_key"
 require_relative "pq/algorithms/hybrid_eddsa"
 
 module JWT
+  # Post-quantum signature support for the ruby-jwt ecosystem.
+  #
+  # Provides ML-DSA (FIPS 204) signatures as JWT algorithms `ML-DSA-44`,
+  # `ML-DSA-65`, and `ML-DSA-87`, plus optional hybrid modes `EdDSA+ML-DSA-*`
+  # that concatenate an Ed25519 signature with an ML-DSA signature.
+  #
+  # @example Encode a JWT with ML-DSA-65
+  #   key = JWT::PQ::Key.generate(:ml_dsa_65)
+  #   token = JWT.encode({ sub: "user-1" }, key, "ML-DSA-65")
+  #
+  # @example Decode and verify
+  #   decoded, _header = JWT.decode(token, key, true, algorithms: ["ML-DSA-65"])
+  #
+  # @see https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf FIPS 204 (ML-DSA)
+  # @see https://datatracker.ietf.org/doc/draft-ietf-cose-dilithium/ draft-ietf-cose-dilithium
   module PQ
-    # Whether jwt-eddsa / ed25519 is available for hybrid mode.
+    # Whether the `ed25519` (or `jwt-eddsa`) gem is available for hybrid mode.
+    #
+    # Hybrid `EdDSA+ML-DSA-*` algorithms require the `ed25519` gem at runtime.
+    # This method probes for it without raising, so callers can decide whether
+    # to offer hybrid options.
+    #
+    # @return [Boolean] true when `ed25519` can be required, false otherwise.
     def self.hybrid_available?
       require "ed25519"
       true

--- a/lib/jwt/pq/algorithms/hybrid_eddsa.rb
+++ b/lib/jwt/pq/algorithms/hybrid_eddsa.rb
@@ -5,11 +5,16 @@ require "jwt"
 module JWT
   module PQ
     module Algorithms
+      # @api private
+      #
       # JWT signing algorithm for hybrid EdDSA + ML-DSA signatures.
       #
       # The signature is a simple concatenation: ed25519_sig (64 bytes) || ml_dsa_sig.
       # This allows PQ-aware verifiers to validate both, while the fixed 64-byte
       # Ed25519 prefix makes it possible to split the signatures deterministically.
+      #
+      # Users interact with these algorithms via `JWT.encode`/`JWT.decode` by
+      # name (`"EdDSA+ML-DSA-*"`); they never instantiate this class directly.
       class HybridEdDsa
         include ::JWT::JWA::SigningAlgorithm
 

--- a/lib/jwt/pq/algorithms/ml_dsa.rb
+++ b/lib/jwt/pq/algorithms/ml_dsa.rb
@@ -4,9 +4,17 @@ require "jwt"
 
 module JWT
   module PQ
+    # @api private
+    #
+    # ruby-jwt `SigningAlgorithm` implementations that register jwt-pq's
+    # algorithms on load. Not intended for direct use.
     module Algorithms
+      # @api private
+      #
       # JWT signing algorithm implementation for ML-DSA (FIPS 204).
       # Registers ML-DSA-44, ML-DSA-65, and ML-DSA-87 with the ruby-jwt library.
+      # Users interact with these algorithms via `JWT.encode`/`JWT.decode` by
+      # name; they never instantiate this class directly.
       class MlDsa
         include ::JWT::JWA::SigningAlgorithm
 

--- a/lib/jwt/pq/errors.rb
+++ b/lib/jwt/pq/errors.rb
@@ -2,16 +2,23 @@
 
 module JWT
   module PQ
+    # Base class for all jwt-pq errors.
     class Error < StandardError; end
 
+    # Raised when liboqs reports a failure or is missing at load time.
     class LiboqsError < Error; end
 
+    # Raised when a requested algorithm name is not supported.
     class UnsupportedAlgorithmError < Error; end
 
+    # Raised for malformed keys, wrong key types, or invalid key material.
     class KeyError < Error; end
 
+    # Raised when an optional runtime dependency (e.g. `ed25519` for hybrid
+    # mode) is needed but not installed.
     class MissingDependencyError < Error; end
 
+    # Raised when a signing operation fails inside liboqs.
     class SignatureError < Error; end
   end
 end

--- a/lib/jwt/pq/hybrid_key.rb
+++ b/lib/jwt/pq/hybrid_key.rb
@@ -2,13 +2,47 @@
 
 module JWT
   module PQ
-    # Composite key combining an Ed25519 keypair with an ML-DSA keypair
-    # for hybrid EdDSA + ML-DSA JWT signatures.
+    # A composite key that pairs an Ed25519 keypair with an ML-DSA keypair
+    # for hybrid `EdDSA+ML-DSA-*` JWT signatures.
+    #
+    # Hybrid mode concatenates the two signatures (`ed25519 || ml_dsa`) so
+    # that a verifier only accepts the token if **both** signatures are
+    # valid. The classical half remains secure against today's attackers
+    # while the post-quantum half resists a future cryptographically
+    # relevant quantum computer.
+    #
+    # Requires the `ed25519` gem (or `jwt-eddsa`, which depends on it).
+    # Use {JWT::PQ.hybrid_available?} to probe availability.
+    #
+    # @example Generate a hybrid key and encode a JWT
+    #   key = JWT::PQ::HybridKey.generate(:ml_dsa_65)
+    #   token = JWT.encode({ sub: "u-1" }, key, "EdDSA+ML-DSA-65")
+    #
+    # @example Verification-only hybrid key
+    #   verifier = JWT::PQ::HybridKey.new(
+    #     ed25519: ed25519_verify_key,
+    #     ml_dsa:  JWT::PQ::Key.from_public_key(:ml_dsa_65, pub_bytes)
+    #   )
     class HybridKey
-      attr_reader :ed25519_signing_key, :ed25519_verify_key, :ml_dsa_key
+      # @return [Ed25519::SigningKey, nil] Ed25519 signing key, or nil for
+      #   verification-only.
+      attr_reader :ed25519_signing_key
 
-      # @param ed25519 [Ed25519::SigningKey, Ed25519::VerifyKey] Ed25519 key
-      # @param ml_dsa [JWT::PQ::Key] ML-DSA key
+      # @return [Ed25519::VerifyKey] Ed25519 verification key.
+      attr_reader :ed25519_verify_key
+
+      # @return [JWT::PQ::Key] ML-DSA keypair (public-only or full).
+      attr_reader :ml_dsa_key
+
+      # Build a hybrid key from existing Ed25519 and ML-DSA components.
+      #
+      # Pass an `Ed25519::SigningKey` for a full signing key, or an
+      # `Ed25519::VerifyKey` for verification-only.
+      #
+      # @param ed25519 [Ed25519::SigningKey, Ed25519::VerifyKey] Ed25519 key.
+      # @param ml_dsa [JWT::PQ::Key] ML-DSA keypair.
+      # @raise [MissingDependencyError] if the `ed25519` gem is not installed.
+      # @raise [KeyError] if `ed25519` is not one of the accepted key types.
       def initialize(ed25519:, ml_dsa:)
         require_eddsa_dependency!
 
@@ -26,7 +60,15 @@ module JWT
         end
       end
 
-      # Generate a new hybrid keypair.
+      # Generate a fresh hybrid keypair.
+      #
+      # Creates both an Ed25519 `SigningKey` and an ML-DSA keypair of the
+      # requested parameter set.
+      #
+      # @param ml_dsa_algorithm [Symbol, String] one of `:ml_dsa_44`,
+      #   `:ml_dsa_65`, `:ml_dsa_87`. Defaults to `:ml_dsa_65`.
+      # @return [HybridKey] a full hybrid keypair (signing + verification).
+      # @raise [MissingDependencyError] if the `ed25519` gem is not installed.
       def self.generate(ml_dsa_algorithm = :ml_dsa_65)
         require_eddsa_dependency!
 
@@ -36,23 +78,29 @@ module JWT
         new(ed25519: ed_key, ml_dsa: ml_key)
       end
 
-      # Whether both keys have private components (can sign).
+      # @return [Boolean] true when both halves have private components and
+      #   the key can be used for signing.
       def private?
         !@ed25519_signing_key.nil? && @ml_dsa_key.private?
       end
 
-      # The ML-DSA algorithm name (e.g., "ML-DSA-65").
+      # @return [String] the ML-DSA algorithm name (e.g. `"ML-DSA-65"`).
       def algorithm
         @ml_dsa_key.algorithm
       end
 
-      # The hybrid algorithm name (e.g., "EdDSA+ML-DSA-65").
+      # @return [String] the hybrid JWT algorithm name
+      #   (e.g. `"EdDSA+ML-DSA-65"`).
       def hybrid_algorithm
         "EdDSA+#{@ml_dsa_key.algorithm}"
       end
 
-      # Zero and discard private key material from both key components.
-      # After calling this, the key can only be used for verification.
+      # Zero and discard private key material from both halves.
+      #
+      # After calling this, {#private?} becomes false and the key can only
+      # be used for verification. Idempotent — safe on verification-only keys.
+      #
+      # @return [true]
       def destroy!
         @ml_dsa_key.destroy!
         if @ed25519_signing_key
@@ -63,11 +111,13 @@ module JWT
         true
       end
 
+      # @return [String] short diagnostic string — never contains key material.
       def inspect
         "#<#{self.class} algorithm=#{hybrid_algorithm} private=#{private?}>"
       end
       alias to_s inspect
 
+      # @api private
       def self.require_eddsa_dependency!
         require "ed25519"
       rescue LoadError

--- a/lib/jwt/pq/jwk.rb
+++ b/lib/jwt/pq/jwk.rb
@@ -5,19 +5,37 @@ require "openssl"
 
 module JWT
   module PQ
-    # JWK (JSON Web Key) support for ML-DSA keys.
+    # JWK (JSON Web Key) import/export for ML-DSA keys.
     #
-    # Follows the draft-ietf-cose-dilithium conventions:
-    #   kty: "AKP" (Algorithm Key Pair)
-    #   alg: "ML-DSA-44", "ML-DSA-65", or "ML-DSA-87"
-    #   pub: base64url-encoded public key
-    #   priv: base64url-encoded private key (optional)
+    # Follows the `draft-ietf-cose-dilithium` conventions for the `AKP`
+    # ("Algorithm Key Pair") key type:
+    #
+    # - `kty`: `"AKP"`
+    # - `alg`: `"ML-DSA-44"`, `"ML-DSA-65"`, or `"ML-DSA-87"`
+    # - `pub`: base64url-encoded public key (no padding)
+    # - `priv`: base64url-encoded private key (optional, no padding)
+    # - `kid`: RFC 7638 thumbprint over the required members
+    #
+    # @example Export and re-import
+    #   jwk = JWT::PQ::JWK.new(key).export
+    #   restored = JWT::PQ::JWK.import(jwk)
+    #
+    # @see https://datatracker.ietf.org/doc/draft-ietf-cose-dilithium/ draft-ietf-cose-dilithium
+    # @see https://www.rfc-editor.org/rfc/rfc7638 RFC 7638 (JWK Thumbprint)
     class JWK
+      # Algorithm names accepted in the `alg` field.
       ALGORITHMS = MlDsa::ALGORITHMS.keys.freeze
+
+      # Value of the `kty` field for all ML-DSA JWKs.
       KTY = "AKP"
 
+      # @return [JWT::PQ::Key] the wrapped key.
       attr_reader :key
 
+      # Wrap a {JWT::PQ::Key} for JWK operations.
+      #
+      # @param key [JWT::PQ::Key] the key to export or thumbprint.
+      # @raise [KeyError] if `key` is not a {JWT::PQ::Key}.
       def initialize(key)
         raise KeyError, "Expected a JWT::PQ::Key, got #{key.class}" unless key.is_a?(JWT::PQ::Key)
 
@@ -25,6 +43,14 @@ module JWT
       end
 
       # Export the key as a JWK hash.
+      #
+      # By default, only the public material is included. Pass
+      # `include_private: true` to emit the `priv` field as well (and only
+      # when the wrapped key actually has a private component).
+      #
+      # @param include_private [Boolean] include the `priv` field. Default: false.
+      # @return [Hash{Symbol=>String}] a JWK with `:kty`, `:alg`, `:pub`,
+      #   `:kid`, and optionally `:priv`.
       def export(include_private: false)
         jwk = {
           kty: KTY,
@@ -39,6 +65,15 @@ module JWT
       end
 
       # Import a Key from a JWK hash.
+      #
+      # Accepts string or symbol keys. Validates `kty`, `alg`, and the
+      # presence/base64url-ness of `pub` (and `priv` if present).
+      #
+      # @param jwk_hash [Hash] a JWK object.
+      # @return [JWT::PQ::Key] a key reconstructed from the JWK — with a
+      #   private component iff the JWK carried a `priv` field.
+      # @raise [KeyError] on missing/wrong `kty`, missing/unsupported `alg`,
+      #   missing `pub`, or invalid base64url in `pub`/`priv`.
       def self.import(jwk_hash)
         jwk = normalize_keys(jwk_hash)
 
@@ -56,14 +91,20 @@ module JWT
         end
       end
 
-      # JWK Thumbprint (RFC 7638) for key identification.
-      # Uses the required members: alg, kty, pub.
+      # Compute the JWK Thumbprint (RFC 7638) used as `kid`.
+      #
+      # Hashes the canonical JSON form over the AKP required members
+      # (`alg`, `kty`, `pub`) with SHA-256 and encodes the digest as
+      # base64url without padding.
+      #
+      # @return [String] base64url-encoded SHA-256 thumbprint.
       def thumbprint
         canonical = "{\"alg\":\"#{@key.algorithm}\",\"kty\":\"#{KTY}\",\"pub\":\"#{base64url_encode(@key.public_key)}\"}"
         digest = OpenSSL::Digest::SHA256.digest(canonical)
         base64url_encode(digest)
       end
 
+      # @api private
       def self.validate_kty!(jwk)
         kty = jwk["kty"]
         raise KeyError, "Missing 'kty' in JWK" unless kty
@@ -71,6 +112,7 @@ module JWT
       end
       private_class_method :validate_kty!
 
+      # @api private
       def self.validate_alg!(jwk)
         alg = jwk["alg"]
         raise KeyError, "Missing 'alg' in JWK" unless alg
@@ -80,11 +122,13 @@ module JWT
       end
       private_class_method :validate_alg!
 
+      # @api private
       def self.normalize_keys(hash)
         hash.transform_keys(&:to_s)
       end
       private_class_method :normalize_keys
 
+      # @api private
       def self.decode_field(jwk, field)
         ::Base64.urlsafe_decode64(jwk[field])
       rescue ArgumentError => e

--- a/lib/jwt/pq/key.rb
+++ b/lib/jwt/pq/key.rb
@@ -4,25 +4,62 @@ require "pqc_asn1"
 
 module JWT
   module PQ
-    # Represents an ML-DSA keypair (public + optional private key).
-    # Used as the signing/verification key for JWT operations.
+    # An ML-DSA keypair (public key + optional private key) used for JWT
+    # signing and verification.
+    #
+    # Prefer the class-level constructors over {.new}:
+    #
+    # - {.generate} — create a fresh keypair
+    # - {.from_pem} — import from a combined SPKI or PKCS#8 PEM
+    # - {.from_pem_pair} — import from separate public/private PEMs
+    # - {.from_public_key} — wrap raw public key bytes (verification only)
+    #
+    # @example Generate and sign
+    #   key = JWT::PQ::Key.generate(:ml_dsa_65)
+    #   token = JWT.encode({ sub: "u-1" }, key, "ML-DSA-65")
+    #
+    # @example Verification-only key
+    #   verifier = JWT::PQ::Key.from_public_key(:ml_dsa_65, pub_bytes)
+    #   JWT.decode(token, verifier, true, algorithms: ["ML-DSA-65"])
     class Key # rubocop:disable Metrics/ClassLength
+      # Symbol → canonical algorithm name.
       ALGORITHM_ALIASES = {
         ml_dsa_44: "ML-DSA-44",
         ml_dsa_65: "ML-DSA-65",
         ml_dsa_87: "ML-DSA-87"
       }.freeze
 
+      # Algorithm name → ASN.1 OID.
       ALGORITHM_OIDS = {
         "ML-DSA-44" => PqcAsn1::OID::ML_DSA_44,
         "ML-DSA-65" => PqcAsn1::OID::ML_DSA_65,
         "ML-DSA-87" => PqcAsn1::OID::ML_DSA_87
       }.freeze
 
+      # ASN.1 OID → algorithm name.
       OID_TO_ALGORITHM = ALGORITHM_OIDS.invert.freeze
 
-      attr_reader :algorithm, :public_key, :private_key
+      # @return [String] canonical algorithm name (`"ML-DSA-44"`, `"ML-DSA-65"`, or `"ML-DSA-87"`).
+      attr_reader :algorithm
 
+      # @return [String] raw public key bytes.
+      attr_reader :public_key
+
+      # @return [String, nil] raw private (secret) key bytes, or nil for
+      #   verification-only keys.
+      attr_reader :private_key
+
+      # Low-level constructor. Prefer {.generate}, {.from_pem}, {.from_pem_pair},
+      # or {.from_public_key} in application code.
+      #
+      # @param algorithm [Symbol, String] one of `:ml_dsa_44`, `:ml_dsa_65`,
+      #   `:ml_dsa_87` (or the canonical string form).
+      # @param public_key [String] raw public key bytes of the correct size
+      #   for the algorithm.
+      # @param private_key [String, nil] raw private key bytes, or nil for a
+      #   verification-only key.
+      # @raise [UnsupportedAlgorithmError] if `algorithm` is not recognized.
+      # @raise [KeyError] if a key's byte size does not match the algorithm.
       def initialize(algorithm:, public_key:, private_key: nil)
         @algorithm = resolve_algorithm(algorithm)
         @ml_dsa = MlDsa.new(@algorithm)
@@ -33,6 +70,11 @@ module JWT
       end
 
       # Generate a new keypair for the given algorithm.
+      #
+      # @param algorithm [Symbol, String] one of `:ml_dsa_44`, `:ml_dsa_65`,
+      #   `:ml_dsa_87` (or the canonical string form).
+      # @return [Key] a new keypair with both public and private components.
+      # @raise [UnsupportedAlgorithmError] if `algorithm` is not recognized.
       def self.generate(algorithm)
         alg_name = resolve_algorithm(algorithm)
         ml_dsa = MlDsa.new(alg_name)
@@ -41,30 +83,48 @@ module JWT
         new(algorithm: alg_name, public_key: pk, private_key: sk)
       end
 
-      # Create a Key from raw public key bytes (verification only).
+      # Wrap raw public key bytes for verification-only use.
+      #
+      # @param algorithm [Symbol, String] the algorithm the public key belongs to.
+      # @param public_key_bytes [String] raw public key bytes.
+      # @return [Key] a verification-only key ({#private?} returns false).
       def self.from_public_key(algorithm, public_key_bytes)
         new(algorithm: algorithm, public_key: public_key_bytes)
       end
 
       # Sign data using the private key.
+      #
+      # @param data [String] message bytes to sign.
+      # @return [String] raw signature bytes.
+      # @raise [KeyError] if this key has no private component.
+      # @raise [SignatureError] if liboqs reports a signing failure.
       def sign(data)
         raise KeyError, "Private key not available — cannot sign" unless @private_key
 
         @ml_dsa.sign_with_sk_buffer(data, sk_buffer)
       end
 
-      # Verify a signature using the public key.
+      # Verify a signature against data using the public key.
+      #
+      # @param data [String] message bytes that were signed.
+      # @param signature [String] raw signature bytes produced by {#sign}.
+      # @return [Boolean] true if the signature is valid, false otherwise.
       def verify(data, signature)
         @ml_dsa.verify_with_pk_buffer(data, signature, pk_buffer)
       end
 
-      # Whether this key can be used for signing.
+      # @return [Boolean] true when this key has a private component and can sign.
       def private?
         !@private_key.nil?
       end
 
       # Zero and discard private key material from Ruby memory.
-      # After calling this, the key can only be used for verification.
+      #
+      # After calling this, {#private?} becomes false and the key can only
+      # be used for verification. Idempotent — safe to call multiple times,
+      # and on verification-only keys.
+      #
+      # @return [true]
       def destroy!
         if @private_key
           @private_key.replace("\0" * @private_key.bytesize)
@@ -75,12 +135,21 @@ module JWT
         true
       end
 
+      # @return [String] short diagnostic string — never contains key material.
       def inspect
         "#<#{self.class} algorithm=#{@algorithm} private=#{private?}>"
       end
       alias to_s inspect
 
-      # Import a Key from a PEM string (SPKI or PKCS#8).
+      # Import a Key from a PEM string.
+      #
+      # Accepts both SPKI (public-only) and PKCS#8 (private + embedded public)
+      # PEM documents. For a PKCS#8 PEM that does not carry the public key,
+      # use {.from_pem_pair} with a separate public PEM instead.
+      #
+      # @param pem_string [String] a PEM-encoded key document.
+      # @return [Key] a public-only or full keypair, depending on the PEM format.
+      # @raise [KeyError] for unknown OIDs or PKCS#8 PEMs missing the public key.
       def self.from_pem(pem_string)
         info = PqcAsn1::DER.parse_pem(pem_string)
         alg_name = resolve_oid!(info.oid)
@@ -97,6 +166,15 @@ module JWT
       end
 
       # Import a Key from separate public and private PEM strings.
+      #
+      # Use this when your private PEM is PKCS#8 without an embedded public
+      # key, or when public and private material come from different sources.
+      #
+      # @param public_pem [String] SPKI-encoded public key PEM.
+      # @param private_pem [String] PKCS#8-encoded private key PEM.
+      # @return [Key] a full keypair.
+      # @raise [KeyError] if the OIDs are unknown or the public and private
+      #   PEMs specify different algorithms.
       def self.from_pem_pair(public_pem:, private_pem:)
         pub_info = PqcAsn1::DER.parse_pem(public_pem)
         priv_info = PqcAsn1::DER.parse_pem(private_pem)
@@ -114,14 +192,22 @@ module JWT
         priv_info&.key&.wipe!
       end
 
-      # Export the public key as PEM (SPKI format).
+      # Export the public key as an SPKI PEM string.
+      #
+      # @return [String] a `-----BEGIN PUBLIC KEY-----` PEM document.
       def to_pem
         oid = ALGORITHM_OIDS[@algorithm]
         der = PqcAsn1::DER.build_spki(oid, @public_key)
         PqcAsn1::PEM.encode(der, "PUBLIC KEY")
       end
 
-      # Export the private key as PEM (PKCS#8 format).
+      # Export the private key as a PKCS#8 PEM string.
+      #
+      # The PEM carries both the private key and the public key (so the pair
+      # can later be re-imported with {.from_pem} alone).
+      #
+      # @return [String] a `-----BEGIN PRIVATE KEY-----` PEM document.
+      # @raise [KeyError] if this key has no private component.
       def private_to_pem
         raise KeyError, "Private key not available" unless @private_key
 
@@ -130,10 +216,13 @@ module JWT
         secure_der.to_pem
       end
 
+      # @api private
       def self.resolve_algorithm(algorithm)
         ALGORITHM_ALIASES.fetch(algorithm.to_sym) { algorithm.to_s }
       end
 
+      # @api private
+      #
       # Extract bytes from a PqcAsn1::SecureBuffer using the safe block API.
       # The yielded String shares the SecureBuffer's C-level memory, so
       # String.new / dup / b all get zeroed when the block exits.
@@ -142,10 +231,12 @@ module JWT
         secure_buffer.use { |bytes| bytes.bytes.pack("C*") }
       end
 
+      # @api private
       def self.resolve_oid!(oid)
         OID_TO_ALGORITHM[oid] || raise(KeyError, "Unknown OID in PEM: #{oid.dotted}")
       end
 
+      # @api private
       def self.build_from_pkcs8(info, alg_name)
         raise KeyError, "PKCS#8 PEM for #{alg_name} missing public key. Use from_pem_pair." unless info.public_key
 

--- a/lib/jwt/pq/liboqs.rb
+++ b/lib/jwt/pq/liboqs.rb
@@ -4,6 +4,8 @@ require "ffi"
 
 module JWT
   module PQ
+    # @api private
+    #
     # FFI bindings for liboqs signature operations.
     #
     # Library search order:

--- a/lib/jwt/pq/ml_dsa.rb
+++ b/lib/jwt/pq/ml_dsa.rb
@@ -2,6 +2,8 @@
 
 module JWT
   module PQ
+    # @api private
+    #
     # Ruby wrapper around liboqs ML-DSA operations.
     # Handles memory allocation, FFI calls, and cleanup.
     class MlDsa

--- a/lib/jwt/pq/version.rb
+++ b/lib/jwt/pq/version.rb
@@ -2,6 +2,7 @@
 
 module JWT
   module PQ
+    # Current gem version.
     VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
## Summary

Turns the existing one-line RDoc comments on the public API into structured YARD docs. `rubydoc.info/gems/jwt-pq` currently only renders the README — after release, each class/method gets a proper reference page with parameters, return types, raised errors, and examples.

**Scope**:

- `JWT::PQ` module + `hybrid_available?`
- `JWT::PQ::Key` — `new`, `generate`, `from_public_key`, `from_pem`, `from_pem_pair`, `sign`, `verify`, `private?`, `destroy!`, `to_pem`, `private_to_pem`, `inspect`, attr readers
- `JWT::PQ::HybridKey` — `new`, `generate`, `private?`, `algorithm`, `hybrid_algorithm`, `destroy!`, `inspect`, attr readers
- `JWT::PQ::JWK` — `new`, `export`, `import`, `thumbprint`
- `JWT::PQ::Error` hierarchy — one-line description per error class

**Hidden from user-facing docs** (marked `@api private`):

- `JWT::PQ::MlDsa` (liboqs FFI wrapper)
- `JWT::PQ::LibOQS` (raw FFI bindings)
- `JWT::PQ::Algorithms::MlDsa` / `::HybridEdDsa` (ruby-jwt `SigningAlgorithm` registrations; users invoke them by string name through `JWT.encode`/`JWT.decode`, never directly)

**Tooling**:

- `.yardopts` drives a consistent build: markdown markup, README.md as the front page, CHANGELOG.md + SECURITY.md linked, internal/private items filtered out.
- `yard` added as dev/test dep in the Gemfile.
- `doc/` and `.yardoc` already gitignored.

**No behavior changes.**

## Test plan

- [x] `bundle exec rspec` — 228 examples, 0 failures, 100.0% line coverage.
- [x] `bundle exec rubocop` — no offenses.
- [x] `bundle exec yard doc` — builds cleanly; 80% documented (the remaining 20% is all inside `@api private` internals, which is the intended state).