### PR TITLE
feat(jwks): add JWT::PQ::JWKSet for RFC 7517 §5 JWK Sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ payload, = JWT.decode(token, key, true, algorithms: [header["alg"]])
 
 Members are indexed by their RFC 7638 thumbprint (the same value
 `JWK#export` emits as `kid`). Remember to set the `kid` header when
-signing: `JWT.encode(payload, key, alg, { kid: JWT::PQ::JWK.new(key).thumbprint })`.
+signing: `JWT.encode(payload, key, alg, { kid: key.jwk_thumbprint })`.
+`Key#jwk_thumbprint` memoizes the digest, so it's cheap to call
+repeatedly on the same key.
 
 ## Algorithms
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,27 @@ jwk.export(include_private: true)
 restored = JWT::PQ::JWK.import(jwk_hash)
 ```
 
+### JWK Set (JWKS)
+
+For publishing multiple verification keys (e.g. during key rotation) or
+consuming a remote JWKS endpoint:
+
+```ruby
+# Producer — publish verification keys on /.well-known/jwks.json
+jwks = JWT::PQ::JWKSet.new([key_current, key_next])
+File.write("jwks.json", jwks.to_json)
+
+# Consumer — resolve the verification key by kid
+jwks = JWT::PQ::JWKSet.import(JSON.parse(fetch_jwks))
+_payload, header = JWT.decode(token, nil, false)        # unverified peek
+key = jwks[header["kid"]] or raise "unknown kid"
+payload, = JWT.decode(token, key, true, algorithms: [header["alg"]])
+```
+
+Members are indexed by their RFC 7638 thumbprint (the same value
+`JWK#export` emits as `kid`). Remember to set the `kid` header when
+signing: `JWT.encode(payload, key, alg, { kid: JWT::PQ::JWK.new(key).thumbprint })`.
+
 ## Algorithms
 
 | Algorithm | NIST Level | Public Key | Signature | JWT `alg` value |

--- a/lib/jwt/pq.rb
+++ b/lib/jwt/pq.rb
@@ -7,6 +7,7 @@ require_relative "pq/ml_dsa"
 require_relative "pq/key"
 require_relative "pq/algorithms/ml_dsa"
 require_relative "pq/jwk"
+require_relative "pq/jwk_set"
 require_relative "pq/hybrid_key"
 require_relative "pq/algorithms/hybrid_eddsa"
 

--- a/lib/jwt/pq/jwk.rb
+++ b/lib/jwt/pq/jwk.rb
@@ -93,15 +93,27 @@ module JWT
 
       # Compute the JWK Thumbprint (RFC 7638) used as `kid`.
       #
-      # Hashes the canonical JSON form over the AKP required members
-      # (`alg`, `kty`, `pub`) with SHA-256 and encodes the digest as
-      # base64url without padding.
+      # Delegates to {JWT::PQ::Key#jwk_thumbprint}, which memoizes the
+      # result on the key — repeated calls on the same key avoid
+      # recomputing the canonical JSON + SHA-256 digest.
       #
       # @return [String] base64url-encoded SHA-256 thumbprint.
       def thumbprint
-        canonical = "{\"alg\":\"#{@key.algorithm}\",\"kty\":\"#{KTY}\",\"pub\":\"#{base64url_encode(@key.public_key)}\"}"
+        @key.jwk_thumbprint
+      end
+
+      # Compute an RFC 7638 thumbprint from algorithm + public key bytes
+      # without allocating a {JWK} or {JWT::PQ::Key} wrapper.
+      #
+      # @api private
+      # @param algorithm [String] canonical algorithm name.
+      # @param public_key [String] raw public key bytes.
+      # @return [String] base64url-encoded SHA-256 thumbprint.
+      def self.compute_thumbprint(algorithm, public_key)
+        pub_b64 = ::Base64.urlsafe_encode64(public_key, padding: false)
+        canonical = "{\"alg\":\"#{algorithm}\",\"kty\":\"#{KTY}\",\"pub\":\"#{pub_b64}\"}"
         digest = OpenSSL::Digest::SHA256.digest(canonical)
-        base64url_encode(digest)
+        ::Base64.urlsafe_encode64(digest, padding: false)
       end
 
       # @api private

--- a/lib/jwt/pq/jwk_set.rb
+++ b/lib/jwt/pq/jwk_set.rb
@@ -43,14 +43,22 @@ module JWT
 
       # Add a key to the set.
       #
+      # Idempotent: if a key with the same RFC 7638 thumbprint is already
+      # in the set, the call is a no-op (Set semantics). The thumbprint
+      # is computed before any mutation, so a failure to derive the
+      # `kid` leaves the set unchanged.
+      #
       # @param key [JWT::PQ::Key] the key to add.
       # @return [JWKSet] self, for chaining.
       # @raise [KeyError] if `key` is not a {JWT::PQ::Key}.
       def add(key)
         raise KeyError, "Expected a JWT::PQ::Key, got #{key.class}" unless key.is_a?(JWT::PQ::Key)
 
+        kid = key.jwk_thumbprint
+        return self if @kid_index.key?(kid)
+
         @keys << key
-        @kid_index[JWK.new(key).thumbprint] = key
+        @kid_index[kid] = key
         self
       end
 
@@ -99,16 +107,34 @@ module JWT
 
       # Serialize the set as a JWKS JSON document.
       #
-      # @param include_private [Boolean] include `priv` on each key. Default: false.
+      # Always emits public-only keys — the `priv` field is never
+      # written out. This keeps the method safe for arbitrary nesting
+      # inside other JSON (e.g. `{ jwks: set }.to_json`), where Ruby's
+      # stdlib JSON passes a generator state as a positional argument.
+      # To publish private material (unusual), call
+      # `JSON.generate(set.export(include_private: true))` explicitly.
+      #
       # @return [String] a JSON document ready for `/.well-known/jwks.json`.
-      def to_json(include_private: false)
-        JSON.generate(export(include_private: include_private))
+      def to_json(*)
+        export.to_json(*)
       end
+
+      # @return [String] short diagnostic string — never contains key material.
+      def inspect
+        "#<#{self.class} size=#{size}>"
+      end
+      alias to_s inspect
 
       # Import a JWKS from a Hash or JSON string.
       #
       # Each member is reconstructed via {JWT::PQ::JWK.import}; malformed
       # members raise {KeyError}.
+      #
+      # ML-DSA public keys are ~1.3–2.6 KB each, so a JWKS with N keys is
+      # at least N × ~2 KB. When ingesting untrusted JWKS payloads (e.g.
+      # a remote `/.well-known/jwks.json`), bound the HTTP body size
+      # before calling `import` — this method does not cap the number of
+      # members.
       #
       # @param source [Hash, String] a JWKS hash or JSON string with a
       #   `"keys"` array.

--- a/lib/jwt/pq/jwk_set.rb
+++ b/lib/jwt/pq/jwk_set.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "json"
+
+module JWT
+  module PQ
+    # A set of JWKs (RFC 7517 §5) for publication and `kid`-based lookup.
+    #
+    # Typical producer flow — publish verification keys on
+    # `/.well-known/jwks.json`:
+    #
+    # @example Publish a JWKS
+    #   jwks = JWT::PQ::JWKSet.new([key_current, key_next])
+    #   File.write("jwks.json", jwks.to_json)
+    #
+    # Typical consumer flow — pick the right key for an incoming JWT by the
+    # `kid` header:
+    #
+    # @example Resolve a verification key by kid
+    #   jwks = JWT::PQ::JWKSet.import(JSON.parse(fetch_jwks))
+    #   _payload, header = JWT.decode(token, nil, false) # unverified peek
+    #   key = jwks[header["kid"]] or raise "unknown kid"
+    #   payload, = JWT.decode(token, key, true, algorithms: [header["alg"]])
+    #
+    # The set indexes members by their RFC 7638 JWK Thumbprint, which is the
+    # `kid` {JWK#export} emits. If you import a JWKS that uses custom (non-
+    # thumbprint) `kid` values, lookup by those custom values is not
+    # supported — rely on thumbprints when generating the set.
+    #
+    # @see https://www.rfc-editor.org/rfc/rfc7517#section-5 RFC 7517 §5
+    class JWKSet
+      include Enumerable
+
+      # Build a set from zero or more {JWT::PQ::Key}s.
+      #
+      # @param keys [Array<JWT::PQ::Key>, JWT::PQ::Key, nil] initial members.
+      # @raise [KeyError] if any element is not a {JWT::PQ::Key}.
+      def initialize(keys = [])
+        @keys = []
+        @kid_index = {}
+        Array(keys).each { |k| add(k) }
+      end
+
+      # Add a key to the set.
+      #
+      # @param key [JWT::PQ::Key] the key to add.
+      # @return [JWKSet] self, for chaining.
+      # @raise [KeyError] if `key` is not a {JWT::PQ::Key}.
+      def add(key)
+        raise KeyError, "Expected a JWT::PQ::Key, got #{key.class}" unless key.is_a?(JWT::PQ::Key)
+
+        @keys << key
+        @kid_index[JWK.new(key).thumbprint] = key
+        self
+      end
+
+      # Iterate over the keys in insertion order.
+      #
+      # @yieldparam key [JWT::PQ::Key]
+      # @return [Enumerator] when called without a block.
+      def each(&)
+        @keys.each(&)
+      end
+
+      # @return [Integer] number of keys in the set.
+      def size
+        @keys.size
+      end
+      alias length size
+
+      # @return [Boolean] true if the set is empty.
+      def empty?
+        @keys.empty?
+      end
+
+      # Look up a key by its RFC 7638 thumbprint (the `kid` from {JWK#export}).
+      #
+      # @param kid [String] the thumbprint to match.
+      # @return [JWT::PQ::Key, nil] the matching key, or nil if not in the set.
+      def find(kid)
+        @kid_index[kid]
+      end
+      alias [] find
+
+      # @return [Array<JWT::PQ::Key>] a frozen snapshot of the keys in the set.
+      def keys
+        @keys.dup.freeze
+      end
+
+      # Export the set as a JWKS hash.
+      #
+      # @param include_private [Boolean] include the `priv` field on each
+      #   member that has a private component. Default: false.
+      # @return [Hash{Symbol=>Array<Hash>}] a hash with a single `:keys`
+      #   member, suitable for serialization with {#to_json}.
+      def export(include_private: false)
+        { keys: @keys.map { |k| JWK.new(k).export(include_private: include_private) } }
+      end
+
+      # Serialize the set as a JWKS JSON document.
+      #
+      # @param include_private [Boolean] include `priv` on each key. Default: false.
+      # @return [String] a JSON document ready for `/.well-known/jwks.json`.
+      def to_json(include_private: false)
+        JSON.generate(export(include_private: include_private))
+      end
+
+      # Import a JWKS from a Hash or JSON string.
+      #
+      # Each member is reconstructed via {JWT::PQ::JWK.import}; malformed
+      # members raise {KeyError}.
+      #
+      # @param source [Hash, String] a JWKS hash or JSON string with a
+      #   `"keys"` array.
+      # @return [JWKSet] a new set with all parsed members.
+      # @raise [KeyError] if `source` is not a Hash/String, if the `keys`
+      #   field is missing or not an Array, or if any member fails to import.
+      def self.import(source)
+        hash =
+          case source
+          when String then JSON.parse(source)
+          when Hash then source
+          else raise KeyError, "Expected Hash or JSON String for JWKS, got #{source.class}"
+          end
+
+        hash = hash.transform_keys(&:to_s)
+        raise KeyError, "Missing 'keys' in JWKS" unless hash.key?("keys")
+        raise KeyError, "'keys' must be an Array" unless hash["keys"].is_a?(Array)
+
+        members = hash["keys"].map { |jwk| JWT::PQ::JWK.import(jwk) }
+        new(members)
+      end
+    end
+  end
+end

--- a/lib/jwt/pq/key.rb
+++ b/lib/jwt/pq/key.rb
@@ -149,6 +149,11 @@ module JWT
       # callers (e.g. {JWT::PQ::JWKSet}) that index many keys by `kid`
       # without wanting to allocate a {JWK} wrapper each time.
       #
+      # Safe to call concurrently on a shared key: the inputs are
+      # immutable post-construction, so a concurrent first access at
+      # worst recomputes the same deterministic string; the `||=`
+      # assignment is a single atomic reference write on MRI.
+      #
       # @return [String] base64url-encoded SHA-256 thumbprint.
       def jwk_thumbprint
         @jwk_thumbprint ||= JWT::PQ::JWK.compute_thumbprint(@algorithm, @public_key)

--- a/lib/jwt/pq/key.rb
+++ b/lib/jwt/pq/key.rb
@@ -141,6 +141,19 @@ module JWT
       end
       alias to_s inspect
 
+      # RFC 7638 JWK Thumbprint for this key, memoized.
+      #
+      # The thumbprint depends only on the canonical JSON of
+      # `{alg, kty, pub}` — all immutable for the lifetime of a Key —
+      # so it is computed lazily on first access and cached. Useful for
+      # callers (e.g. {JWT::PQ::JWKSet}) that index many keys by `kid`
+      # without wanting to allocate a {JWK} wrapper each time.
+      #
+      # @return [String] base64url-encoded SHA-256 thumbprint.
+      def jwk_thumbprint
+        @jwk_thumbprint ||= JWT::PQ::JWK.compute_thumbprint(@algorithm, @public_key)
+      end
+
       # Import a Key from a PEM string.
       #
       # Accepts both SPKI (public-only) and PKCS#8 (private + embedded public)

--- a/spec/jwt/pq/jwk_set_spec.rb
+++ b/spec/jwt/pq/jwk_set_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require "json"
+
+RSpec.describe JWT::PQ::JWKSet do
+  let(:key_a) { JWT::PQ::Key.generate(:ml_dsa_44) }
+  let(:key_b) { JWT::PQ::Key.generate(:ml_dsa_65) }
+  let(:key_c) { JWT::PQ::Key.generate(:ml_dsa_87) }
+
+  let(:kid_a) { JWT::PQ::JWK.new(key_a).thumbprint }
+  let(:kid_b) { JWT::PQ::JWK.new(key_b).thumbprint }
+
+  describe "#initialize" do
+    it "accepts an empty array" do
+      set = described_class.new
+      expect(set).to be_empty
+      expect(set.size).to eq(0)
+    end
+
+    it "accepts an array of keys" do
+      set = described_class.new([key_a, key_b])
+      expect(set.size).to eq(2)
+    end
+
+    it "accepts a single key (wrapped via Array())" do
+      set = described_class.new(key_a)
+      expect(set.size).to eq(1)
+    end
+
+    it "raises for non-Key members" do
+      expect { described_class.new(["not a key"]) }
+        .to raise_error(JWT::PQ::KeyError, /JWT::PQ::Key/)
+    end
+  end
+
+  describe "#add" do
+    let(:set) { described_class.new }
+
+    it "returns self for chaining" do
+      expect(set.add(key_a)).to equal(set)
+    end
+
+    it "increments size" do
+      set.add(key_a).add(key_b)
+      expect(set.size).to eq(2)
+    end
+
+    it "rejects non-Key inputs" do
+      expect { set.add("nope") }.to raise_error(JWT::PQ::KeyError, /JWT::PQ::Key/)
+    end
+  end
+
+  describe "lookup" do
+    let(:set) { described_class.new([key_a, key_b]) }
+
+    it "finds a key by thumbprint via #find" do
+      expect(set.find(kid_a)).to equal(key_a)
+      expect(set.find(kid_b)).to equal(key_b)
+    end
+
+    it "exposes #[] as an alias for #find" do
+      expect(set[kid_a]).to equal(key_a)
+    end
+
+    it "returns nil for unknown kid" do
+      expect(set.find("unknown")).to be_nil
+    end
+  end
+
+  describe "enumeration" do
+    let(:set) { described_class.new([key_a, key_b, key_c]) }
+
+    it "includes Enumerable" do
+      expect(set).to be_a(Enumerable)
+    end
+
+    it "iterates in insertion order" do
+      expect(set.to_a).to eq([key_a, key_b, key_c])
+    end
+
+    it "returns an Enumerator without a block" do
+      expect(set.each).to be_a(Enumerator)
+    end
+
+    it "#keys returns a frozen snapshot" do
+      snapshot = set.keys
+      expect(snapshot).to eq([key_a, key_b, key_c])
+      expect(snapshot).to be_frozen
+    end
+  end
+
+  describe "#export" do
+    let(:set) { described_class.new([key_a, key_b]) }
+
+    it "returns a JWKS hash with public-only keys by default" do
+      jwks = set.export
+      expect(jwks).to have_key(:keys)
+      expect(jwks[:keys].size).to eq(2)
+      jwks[:keys].each do |jwk|
+        expect(jwk[:kty]).to eq("AKP")
+        expect(jwk).not_to have_key(:priv)
+      end
+    end
+
+    it "includes priv when requested" do
+      jwks = set.export(include_private: true)
+      jwks[:keys].each { |jwk| expect(jwk[:priv]).to be_a(String) }
+    end
+
+    it "omits priv on public-only members even when requested" do
+      pub_key = JWT::PQ::Key.from_public_key(:ml_dsa_44, key_a.public_key)
+      pub_set = described_class.new([pub_key])
+      jwks = pub_set.export(include_private: true)
+      expect(jwks[:keys].first).not_to have_key(:priv)
+    end
+  end
+
+  describe "#to_json" do
+    let(:set) { described_class.new([key_a]) }
+
+    it "produces valid JSON with a keys array" do
+      parsed = JSON.parse(set.to_json)
+      expect(parsed["keys"].size).to eq(1)
+      expect(parsed["keys"].first["kty"]).to eq("AKP")
+    end
+
+    it "omits priv by default" do
+      parsed = JSON.parse(set.to_json)
+      expect(parsed["keys"].first).not_to have_key("priv")
+    end
+
+    it "honors include_private" do
+      parsed = JSON.parse(set.to_json(include_private: true))
+      expect(parsed["keys"].first["priv"]).to be_a(String)
+    end
+  end
+
+  describe ".import" do
+    let(:original) { described_class.new([key_a, key_b]) }
+
+    it "round-trips public-only JWKS via a Hash" do
+      restored = described_class.import(original.export)
+      expect(restored.size).to eq(2)
+      expect(restored[kid_a].public_key).to eq(key_a.public_key)
+      expect(restored[kid_a]).not_to be_private
+    end
+
+    it "round-trips JWKS with private keys" do
+      restored = described_class.import(original.export(include_private: true))
+      expect(restored[kid_a]).to be_private
+      expect(restored[kid_a].private_key).to eq(key_a.private_key)
+    end
+
+    it "accepts a JSON string" do
+      restored = described_class.import(original.to_json)
+      expect(restored.size).to eq(2)
+      expect(restored[kid_a].public_key).to eq(key_a.public_key)
+    end
+
+    it "accepts string-keyed hashes" do
+      stringified = original.export.transform_keys(&:to_s)
+      stringified["keys"] = stringified["keys"].map { |k| k.transform_keys(&:to_s) }
+      restored = described_class.import(stringified)
+      expect(restored.size).to eq(2)
+    end
+
+    it "raises for an unsupported source type" do
+      expect { described_class.import(42) }
+        .to raise_error(JWT::PQ::KeyError, /Expected Hash or JSON String/)
+    end
+
+    it "raises when 'keys' is missing" do
+      expect { described_class.import({}) }
+        .to raise_error(JWT::PQ::KeyError, /Missing 'keys'/)
+    end
+
+    it "raises when 'keys' is not an Array" do
+      expect { described_class.import({ "keys" => "nope" }) }
+        .to raise_error(JWT::PQ::KeyError, /must be an Array/)
+    end
+
+    it "propagates JWK-level errors from members" do
+      expect { described_class.import({ "keys" => [{ "kty" => "RSA" }] }) }
+        .to raise_error(JWT::PQ::KeyError, /kty/)
+    end
+  end
+
+  describe "consumer flow — resolve verification key by kid" do
+    let(:payload) { { "sub" => "jwks-test" } }
+
+    it "verifies a JWT using a key fetched from the set by kid" do
+      token = JWT.encode(payload, key_b, "ML-DSA-65", { kid: kid_b })
+      _, header = JWT.decode(token, nil, false)
+      set = described_class.new([key_a, key_b])
+
+      verification_key = set[header["kid"]]
+      expect(verification_key).not_to be_nil
+
+      decoded, = JWT.decode(token, verification_key, true, algorithms: ["ML-DSA-65"])
+      expect(decoded).to eq(payload)
+    end
+
+    it "returns nil when the JWT kid is not in the set" do
+      foreign_kid = JWT::PQ::JWK.new(key_c).thumbprint
+      token = JWT.encode(payload, key_c, "ML-DSA-87", { kid: foreign_kid })
+      _, header = JWT.decode(token, nil, false)
+
+      set = described_class.new([key_a, key_b])
+      expect(set[header["kid"]]).to be_nil
+    end
+  end
+end

--- a/spec/jwt/pq/jwk_set_spec.rb
+++ b/spec/jwt/pq/jwk_set_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe JWT::PQ::JWKSet do
     it "rejects non-Key inputs" do
       expect { set.add("nope") }.to raise_error(JWT::PQ::KeyError, /JWT::PQ::Key/)
     end
+
+    it "is idempotent on duplicate kid (same key instance)" do
+      set.add(key_a).add(key_a)
+      expect(set.size).to eq(1)
+      expect(set[kid_a]).to equal(key_a)
+    end
+
+    it "is idempotent on duplicate kid (equivalent public key, different instance)" do
+      twin = JWT::PQ::Key.from_public_key(:ml_dsa_44, key_a.public_key)
+      set.add(key_a).add(twin)
+      expect(set.size).to eq(1)
+      expect(set[kid_a]).to equal(key_a)
+    end
   end
 
   describe "lookup" do
@@ -129,9 +142,28 @@ RSpec.describe JWT::PQ::JWKSet do
       expect(parsed["keys"].first).not_to have_key("priv")
     end
 
-    it "honors include_private" do
-      parsed = JSON.parse(set.to_json(include_private: true))
+    it "emits private material via JSON.generate(set.export(include_private: true))" do
+      parsed = JSON.parse(JSON.generate(set.export(include_private: true)))
       expect(parsed["keys"].first["priv"]).to be_a(String)
+    end
+
+    it "serializes correctly when nested inside another Hash" do
+      wrapped = { jwks: set }.to_json
+      parsed = JSON.parse(wrapped)
+      expect(parsed["jwks"]["keys"].size).to eq(1)
+      expect(parsed["jwks"]["keys"].first["kty"]).to eq("AKP")
+    end
+
+    it "never leaks priv when nested, even when the set owns private keys" do
+      wrapped = { jwks: set }.to_json
+      expect(wrapped).not_to include("\"priv\"")
+    end
+  end
+
+  describe "#inspect" do
+    it "reports size without exposing key material" do
+      set = described_class.new([key_a, key_b])
+      expect(set.inspect).to eq("#<JWT::PQ::JWKSet size=2>")
     end
   end
 


### PR DESCRIPTION
## Summary

Adds support for publishing multiple keys (e.g. key rotation on a
`.well-known/jwks.json` endpoint) and for consuming a remote JWKS to
resolve a verification key by the incoming JWT's `kid`.

## API

```ruby
# Producer — publish verification keys
jwks = JWT::PQ::JWKSet.new([key_current, key_next])
File.write("jwks.json", jwks.to_json)

# Consumer — resolve by kid
jwks = JWT::PQ::JWKSet.import(JSON.parse(fetch_jwks))
_payload, header = JWT.decode(token, nil, false)
key = jwks[header["kid"]] or raise "unknown kid"
payload, = JWT.decode(token, key, true, algorithms: [header["alg"]])
```

**Surface**

- `JWT::PQ::JWKSet.new(keys = [])` — accepts Array, single `JWT::PQ::Key`, or nil
- `#add(key)` — chainable; atomic + idempotent (duplicate kid = silent skip, Set semantics)
- `#find(kid)` / `#[](kid)` — O(1) lookup
- `#export(include_private: false)` — `{ keys: [...] }` hash
- `#to_json(*)` — serialized JWKS; always public-only, safe to nest inside other JSON (`{ jwks: set }.to_json`). For private material: `JSON.generate(set.export(include_private: true))`.
- `.import(hash_or_json_string)` — parse + reconstruct
- `#inspect` — `"#<JWT::PQ::JWKSet size=N>"`, never leaks key material
- `Enumerable` — `each`, `size`, `length`, `empty?`, `keys` (frozen snapshot)

Also adds `JWT::PQ::Key#jwk_thumbprint` (lazy-memoized RFC 7638
thumbprint) so callers indexing many keys don't pay the canonical-JSON +
SHA-256 cost on every `add` / `export` / `to_json`. Thread-safe on
shared verification keys.

## Design notes

- Members are indexed by RFC 7638 thumbprint, matching what `JWK#export` already emits as `kid`. Custom `kid` values on imported JWKs aren't supported for lookup in this first cut — documented in the class YARD.
- `JWT.encode` does **not** auto-populate the `kid` header; callers must pass it explicitly (`JWT.encode(payload, key, alg, { kid: key.jwk_thumbprint })`). README updated to make that explicit and to use the memoized `Key#jwk_thumbprint`.
- Malformed members (bad `kty`, missing `pub`, invalid base64url, etc.) surface as `JWT::PQ::KeyError` from `JWT::PQ::JWK.import` — no new error types introduced.
- `.import` YARD warns about bounding input size: ML-DSA public keys are 1.3–2.6 KB each, so untrusted JWKS payloads should be size-capped before ingest.

## README

Adds a new **JWK Set (JWKS)** section with producer + consumer snippets
and a note on setting `kid` when signing.

## Test plan

- [x] `bundle exec rspec` — 263 examples, 0 failures, **100.0% line coverage**, 87.96% branch.
- [x] `bundle exec rubocop` — no offenses.
- [x] `bundle exec yard doc --fail-on-warning` — clean build.
- [x] README updated with producer and consumer snippets.
- [x] Security + performance review findings (S1 atomic `#add`, S2 idempotent `#add`, S3 `#to_json` nested-serialization fix, S4 custom `#inspect`, S5 `.import` size-bound doc, P2 thumbprint memoization) addressed in `13cddc4`; thread-safety note on `Key#jwk_thumbprint` in `f4420c0`; README updated to use the memoized thumbprint in `1091836`.