### PR TITLE
test(fuzz): harden JWK / JWKSet import against malformed input

### DIFF
--- a/lib/jwt/pq/jwk.rb
+++ b/lib/jwt/pq/jwk.rb
@@ -73,17 +73,23 @@ module JWT
       # @return [JWT::PQ::Key] a key reconstructed from the JWK — with a
       #   private component iff the JWK carried a `priv` field.
       # @raise [KeyError] on missing/wrong `kty`, missing/unsupported `alg`,
-      #   missing `pub`, or invalid base64url in `pub`/`priv`.
+      #   missing `pub`, wrong field types, or invalid base64url in
+      #   `pub`/`priv`.
       def self.import(jwk_hash)
+        raise KeyError, "Expected a Hash for JWK, got #{jwk_hash.class}" unless jwk_hash.is_a?(Hash)
+
         jwk = normalize_keys(jwk_hash)
 
         validate_kty!(jwk)
         alg = validate_alg!(jwk)
         raise KeyError, "Missing 'pub' in JWK" unless jwk.key?("pub")
+        raise KeyError, "'pub' must be a String, got #{jwk["pub"].class}" unless jwk["pub"].is_a?(String)
 
         pub_bytes = decode_field(jwk, "pub")
 
         if jwk.key?("priv")
+          raise KeyError, "'priv' must be a String, got #{jwk["priv"].class}" unless jwk["priv"].is_a?(String)
+
           priv_bytes = decode_field(jwk, "priv")
           Key.new(algorithm: alg, public_key: pub_bytes, private_key: priv_bytes)
         else

--- a/lib/jwt/pq/jwk_set.rb
+++ b/lib/jwt/pq/jwk_set.rb
@@ -142,12 +142,8 @@ module JWT
       # @raise [KeyError] if `source` is not a Hash/String, if the `keys`
       #   field is missing or not an Array, or if any member fails to import.
       def self.import(source)
-        hash =
-          case source
-          when String then JSON.parse(source)
-          when Hash then source
-          else raise KeyError, "Expected Hash or JSON String for JWKS, got #{source.class}"
-          end
+        hash = coerce_to_hash(source)
+        raise KeyError, "Expected Hash for JWKS body, got #{hash.class}" unless hash.is_a?(Hash)
 
         hash = hash.transform_keys(&:to_s)
         raise KeyError, "Missing 'keys' in JWKS" unless hash.key?("keys")
@@ -156,6 +152,21 @@ module JWT
         members = hash["keys"].map { |jwk| JWT::PQ::JWK.import(jwk) }
         new(members)
       end
+
+      # @api private
+      def self.coerce_to_hash(source)
+        case source
+        when String
+          begin
+            ::JSON.parse(source)
+          rescue ::JSON::ParserError => e
+            raise KeyError, "Invalid JSON for JWKS: #{e.message}"
+          end
+        when Hash then source
+        else raise KeyError, "Expected Hash or JSON String for JWKS, got #{source.class}"
+        end
+      end
+      private_class_method :coerce_to_hash
     end
   end
 end

--- a/spec/jwt/pq/fuzz_spec.rb
+++ b/spec/jwt/pq/fuzz_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+
+# Bounded-reproducible fuzz for the untrusted-input parsers.
+#
+# Anything reaching JWK/JWKS import from the wire (HTTP, disk, user
+# payload) is attacker-influenced. The contract is that malformed
+# input only ever surfaces as JWT::PQ::KeyError — never NoMethodError,
+# TypeError, ArgumentError, JSON::ParserError, or an FFI crash.
+#
+# Deterministic seed so failures are reproducible; batch reporting so
+# all broken mutators surface in a single run.
+FUZZ_SEED = 42
+FUZZ_ITERATIONS = 5
+
+RSpec.describe "Fuzz: parsing untrusted JWK / JWKS input" do
+  let(:rng) { Random.new(FUZZ_SEED) }
+  let(:valid_jwk) do
+    key = JWT::PQ::Key.generate(:ml_dsa_65)
+    JWT::PQ::JWK.new(key).export(include_private: true)
+  end
+
+  def random_bytes(prng, count)
+    Array.new(count) { prng.rand(256) }.pack("C*")
+  end
+
+  def b64(bytes)
+    Base64.urlsafe_encode64(bytes, padding: false)
+  end
+
+  def run_fuzz(mutators)
+    failures = []
+    mutators.each_with_index do |mutator, i|
+      FUZZ_ITERATIONS.times do |j|
+        input = mutator.call
+        begin
+          yield input
+        rescue JWT::PQ::KeyError
+          # expected
+        rescue StandardError => e
+          failures << "mutator=#{i} iter=#{j} input=#{input.inspect[0, 80]} " \
+                      "raised #{e.class}: #{e.message.to_s.lines.first&.strip}"
+        end
+      end
+    end
+    failures
+  end
+
+  describe "JWT::PQ::JWK.import" do
+    it "only surfaces JWT::PQ::KeyError for malformed inputs" do
+      base = valid_jwk
+      r = rng
+      mutators = [
+        # Non-Hash inputs
+        -> {},
+        -> { 42 },
+        -> { "string" },
+        -> { [] },
+        -> { [1, 2, 3] },
+        -> { true },
+        -> { Object.new },
+        -> { JSON.generate(base) },
+
+        # Empty / missing required fields
+        -> { {} },
+        -> { base.dup.tap { |h| h.delete(:kty) } },
+        -> { base.dup.tap { |h| h.delete(:alg) } },
+        -> { base.dup.tap { |h| h.delete(:pub) } },
+
+        # Wrong types for kty
+        -> { base.merge(kty: r.rand(1_000_000)) },
+        -> { base.merge(kty: []) },
+        -> { base.merge(kty: {}) },
+        -> { base.merge(kty: nil) },
+
+        # Wrong types for alg
+        -> { base.merge(alg: r.rand(1_000_000)) },
+        -> { base.merge(alg: [base[:alg]]) },
+        -> { base.merge(alg: nil) },
+        -> { base.merge(alg: {}) },
+
+        # Wrong types for pub
+        -> { base.merge(pub: r.rand(1_000_000)) },
+        -> { base.merge(pub: nil) },
+        -> { base.merge(pub: [base[:pub]]) },
+        -> { base.merge(pub: {}) },
+
+        # Invalid values
+        -> { base.merge(kty: "RSA") },
+        -> { base.merge(alg: "HS256") },
+        -> { base.merge(pub: "!@#$%not-base64") },
+        -> { base.merge(pub: "") },
+        -> { base.merge(priv: "!@#$%not-base64") },
+        -> { base.merge(priv: nil) },
+        -> { base.merge(priv: []) },
+
+        # Truncation / corruption of pub
+        -> { base.merge(pub: base[:pub][0..5]) },
+        -> { base.merge(pub: "#{base[:pub]}XYZ") },
+        -> { base.merge(pub: b64(random_bytes(r, 10))) },
+        -> { base.merge(pub: b64(random_bytes(r, 100_000))) },
+
+        # Unicode / null bytes
+        -> { base.merge(alg: "ML-DSA-65\x00") },
+        -> { base.merge(alg: "ML-DSA-65\u{1F389}") },
+        -> { base.merge(kty: "AKP\x00") },
+
+        # Random noise
+        -> { { kty: random_bytes(r, 8), alg: random_bytes(r, 8), pub: random_bytes(r, 32) } }
+      ]
+
+      failures = run_fuzz(mutators) { |input| JWT::PQ::JWK.import(input) }
+      expect(failures).to be_empty, "Unexpected exceptions:\n#{failures.join("\n")}"
+    end
+  end
+
+  describe "JWT::PQ::JWKSet.import" do
+    it "only surfaces JWT::PQ::KeyError for malformed inputs" do
+      jwk = valid_jwk.dup.tap { |h| h.delete(:priv) }
+      mutators = [
+        # Non-Hash/String
+        -> {},
+        -> { 42 },
+        -> { [] },
+        -> { Object.new },
+        -> { true },
+
+        # Invalid JSON
+        -> { "not valid json" },
+        -> { "{" },
+        -> { '{"keys":' },
+        -> { "" },
+
+        # Valid JSON, wrong top-level shape
+        -> { "42" },
+        -> { "null" },
+        -> { "[]" },
+        -> { "\"string\"" },
+        -> { "true" },
+
+        # Hash but missing / malformed 'keys'
+        -> { {} },
+        -> { { "keys" => "not an array" } },
+        -> { { "keys" => nil } },
+        -> { { "keys" => 42 } },
+        -> { { "keys" => {} } },
+
+        # keys array with non-Hash members
+        -> { { "keys" => [1, 2, 3] } },
+        -> { { "keys" => [nil] } },
+        -> { { "keys" => ["string1"] } },
+        -> { { "keys" => [[]] } },
+
+        # JSON-encoded versions of the above
+        -> { '{"keys":[1,2,3]}' },
+        -> { '{"keys":[null]}' },
+        -> { '{"keys":[{"kty":"RSA"}]}' },
+        -> { '{"keys":[{}]}' },
+
+        # Partially valid (mix)
+        -> { { "keys" => [jwk, { "kty" => "bad" }] } },
+        -> { { "keys" => [jwk, nil] } }
+      ]
+
+      failures = run_fuzz(mutators) { |input| JWT::PQ::JWKSet.import(input) }
+      expect(failures).to be_empty, "Unexpected exceptions:\n#{failures.join("\n")}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a bounded-reproducible fuzz suite over the untrusted-input parsers
(`JWT::PQ::JWK.import`, `JWT::PQ::JWKSet.import`) and fixes the real
bugs it surfaced.

**Contract:** anything coming from the wire — HTTP, disk, user-supplied
JSON — only ever surfaces as `JWT::PQ::KeyError`. Never `NoMethodError`,
`TypeError`, `ArgumentError`, `JSON::ParserError`, or an FFI crash.

## What the fuzz covers

~70 mutators, deterministic seed (42), batched failure reporting:

- Non-Hash / non-String inputs (`nil`, `42`, `[]`, `Object.new`, `true`)
- Valid JSON that parses to non-Hash top-level (`"42"`, `"null"`, `"[]"`, `"true"`)
- Invalid JSON strings (`"{"`, `"not json"`, `""`)
- Missing / wrong-typed required fields (`kty`, `alg`, `pub`, `priv`)
- Truncated / padded / oversized `pub` material
- JWKSet `keys` arrays containing non-Hash members
- Unicode / null-byte injection in `alg` and `kty` strings

## Real bugs surfaced and fixed in this PR

### `JWT::PQ::JWK.import`
- Non-Hash inputs blew up with `NoMethodError` on `#transform_keys`.
- `pub` / `priv` as non-String blew up with `NoMethodError` on Base64's `#end_with?`.
- Both now validated up-front with explicit shape checks.

### `JWT::PQ::JWKSet.import`
- Malformed JSON strings leaked `JSON::ParserError` instead of `KeyError`.
- Valid-JSON-but-not-a-Hash payloads (`"42"`, `"null"`, `"[]"`) blew up on `transform_keys`.
- `JSON::ParserError` was also unreachable due to namespace shadowing (`JWT::JSON::ParserError` vs `::JSON::ParserError`). Fixed with explicit top-level scope.
- Extracted `coerce_to_hash` private class method to keep `#import` under the cyclomatic-complexity threshold after the hardening.

## Test plan

- [x] `bundle exec rspec` — 265 examples, 0 failures, **100.0% line coverage**, 88.79% branch.
- [x] `bundle exec rubocop` — no offenses.
- [x] `bundle exec yard doc --fail-on-warning` — clean build.
- [x] Fuzz spec runs in ~150 ms — cheap enough to stay in the default suite.