### PR TITLE
feat(jwks): add remote JWKS fetcher with TTL cache and ETag revalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,40 @@ signing: `JWT.encode(payload, key, alg, { kid: key.jwk_thumbprint })`.
 `Key#jwk_thumbprint` memoizes the digest, so it's cheap to call
 repeatedly on the same key.
 
+### Fetching a remote JWKS
+
+For consuming a JWKS from an identity provider or sibling service,
+`JWT::PQ::JWKSet.fetch` wraps `Net::HTTP` with a TTL cache and
+`ETag`-based revalidation:
+
+```ruby
+jwks = JWT::PQ::JWKSet.fetch("https://issuer.example/.well-known/jwks.json")
+
+_payload, header = JWT.decode(token, nil, false)
+key = jwks[header["kid"]] or raise "unknown kid"
+payload, = JWT.decode(token, key, true, algorithms: [header["alg"]])
+```
+
+The cache is process-global and keyed by URL, so repeated calls inside
+the TTL window (default: 300 s) return the cached set without touching
+the network. Once the TTL expires, the next call issues a conditional
+GET with `If-None-Match`; a `304 Not Modified` refreshes the cache
+timestamp without re-parsing. Tune via kwargs:
+
+```ruby
+JWT::PQ::JWKSet.fetch(url,
+  cache_ttl: 600,         # seconds; default 300
+  timeout: 3,             # read timeout; default 5
+  open_timeout: 3,        # connect timeout; default 5
+  max_body_bytes: 65_536, # response body cap; default 1 MB
+  allow_http: false)      # reject plain http:// (default)
+```
+
+Defense-in-depth defaults: HTTPS only, redirects rejected, body capped
+at 1 MB, 5 s timeouts. Network/HTTP failures raise
+`JWT::PQ::JWKSFetchError`; malformed JWKS bodies raise
+`JWT::PQ::KeyError`.
+
 ## Algorithms
 
 | Algorithm | NIST Level | Public Key | Signature | JWT `alg` value |

--- a/lib/jwt/pq.rb
+++ b/lib/jwt/pq.rb
@@ -8,6 +8,7 @@ require_relative "pq/key"
 require_relative "pq/algorithms/ml_dsa"
 require_relative "pq/jwk"
 require_relative "pq/jwk_set"
+require_relative "pq/jwks_loader"
 require_relative "pq/hybrid_key"
 require_relative "pq/algorithms/hybrid_eddsa"
 

--- a/lib/jwt/pq/errors.rb
+++ b/lib/jwt/pq/errors.rb
@@ -20,5 +20,10 @@ module JWT
 
     # Raised when a signing operation fails inside liboqs.
     class SignatureError < Error; end
+
+    # Raised when a remote JWKS fetch fails — network error, timeout,
+    # non-2xx response, oversized body, or blocked URL (non-HTTPS, redirect).
+    # Parsing failures on the fetched body still surface as {KeyError}.
+    class JWKSFetchError < Error; end
   end
 end

--- a/lib/jwt/pq/jwk_set.rb
+++ b/lib/jwt/pq/jwk_set.rb
@@ -167,6 +167,30 @@ module JWT
         end
       end
       private_class_method :coerce_to_hash
+
+      # Fetch a JWKS from a URL, honouring the process-global cache.
+      #
+      # Convenience wrapper around {Loader#fetch} using
+      # {Loader.default} — the cache is shared across all callers, so
+      # repeated hits on the same URL within `cache_ttl` seconds return
+      # the in-memory set without touching the network.
+      #
+      # See {Loader} for the full option reference (cache TTL, timeouts,
+      # body-size cap, HTTPS enforcement, ETag-based revalidation).
+      #
+      # @example Verify a token using a remote JWKS
+      #   jwks = JWT::PQ::JWKSet.fetch("https://issuer.example/.well-known/jwks.json")
+      #   _payload, header = JWT.decode(token, nil, false)
+      #   key = jwks[header["kid"]] or raise "unknown kid"
+      #   payload, = JWT.decode(token, key, true, algorithms: [header["alg"]])
+      #
+      # @param url [String] absolute JWKS URL.
+      # @return [JWKSet] the parsed set of verification keys.
+      # @raise [JWKSFetchError] on fetch failure (see {Loader#fetch}).
+      # @raise [KeyError] if the fetched body is not a valid JWKS.
+      def self.fetch(url, **)
+        Loader.default.fetch(url, **)
+      end
     end
   end
 end

--- a/lib/jwt/pq/jwks_loader.rb
+++ b/lib/jwt/pq/jwks_loader.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+
+module JWT
+  module PQ
+    class JWKSet
+      # HTTP-backed JWKS loader with TTL cache and ETag revalidation.
+      #
+      # Fetches a remote JWKS document (e.g. `/.well-known/jwks.json`),
+      # parses it via {JWT::PQ::JWKSet.import}, and caches the result
+      # per-URL. Subsequent calls inside the TTL window return the cached
+      # set without touching the network. Once the TTL expires, an
+      # `If-None-Match` conditional GET is issued using the stored
+      # `ETag`; a `304 Not Modified` response refreshes the cache
+      # timestamp without re-parsing.
+      #
+      # Prefer the {JWT::PQ::JWKSet.fetch} shortcut over instantiating
+      # this class directly — it uses a process-global loader so the
+      # cache is shared across callers.
+      #
+      # Defense-in-depth defaults:
+      #
+      # - HTTPS only (pass `allow_http: true` to override for development).
+      # - Redirects are rejected; update the URL to the canonical location.
+      # - Response body is capped at 1 MB (`max_body_bytes`); ML-DSA public
+      #   keys are ~1.3–2.6 KB each, so 1 MB already allows several hundred
+      #   rotation candidates.
+      # - Read/open timeouts default to 5 seconds.
+      # - Failures raise {JWKSFetchError}; parse errors on the fetched body
+      #   surface as {KeyError} from {JWKSet.import}.
+      #
+      # @example Fetch and verify a token
+      #   jwks = JWT::PQ::JWKSet.fetch("https://issuer.example/.well-known/jwks.json")
+      #   _payload, header = JWT.decode(token, nil, false)
+      #   key = jwks[header["kid"]] or raise "unknown kid"
+      #   payload, = JWT.decode(token, key, true, algorithms: [header["alg"]])
+      class Loader
+        DEFAULT_CACHE_TTL = 300
+        DEFAULT_TIMEOUT = 5
+        DEFAULT_OPEN_TIMEOUT = 5
+        DEFAULT_MAX_BODY_BYTES = 1_048_576
+
+        CacheEntry = Struct.new(:jwks, :etag, :fetched_at)
+        private_constant :CacheEntry
+
+        # @return [Loader] a process-global loader whose cache is shared
+        #   across all {JWKSet.fetch} callers.
+        def self.default
+          @default ||= new
+        end
+
+        # Reset the process-global loader — mainly for tests.
+        # @api private
+        def self.reset_default!
+          @default = nil
+        end
+
+        def initialize
+          @cache = {}
+          @mutex = Mutex.new
+        end
+
+        # Fetch the JWKS at `url`, honouring the cache if the entry is
+        # still fresh.
+        #
+        # @param url [String] the absolute URL of the JWKS document.
+        # @param cache_ttl [Integer] seconds the cached set is considered
+        #   fresh. Default: 300.
+        # @param timeout [Integer] read timeout in seconds. Default: 5.
+        # @param open_timeout [Integer] connect timeout in seconds. Default: 5.
+        # @param max_body_bytes [Integer] cap on response body size.
+        #   Default: 1 MB.
+        # @param allow_http [Boolean] allow plain `http://` URLs. Default:
+        #   false (strongly recommended for production).
+        # @return [JWKSet] the parsed set of verification keys.
+        # @raise [JWKSFetchError] on network error, timeout, non-2xx
+        #   response, oversized body, redirect, or non-HTTPS URL.
+        # @raise [KeyError] if the fetched body is not a valid JWKS.
+        def fetch(url, # rubocop:disable Metrics/ParameterLists
+                  cache_ttl: DEFAULT_CACHE_TTL,
+                  timeout: DEFAULT_TIMEOUT,
+                  open_timeout: DEFAULT_OPEN_TIMEOUT,
+                  max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+                  allow_http: false)
+          uri = validate_uri!(url, allow_http: allow_http)
+
+          fresh = fresh_entry(url, cache_ttl)
+          return fresh.jwks if fresh
+
+          existing = @mutex.synchronize { @cache[url] }
+          result = do_http_get(uri, existing&.etag, timeout, open_timeout, max_body_bytes)
+
+          if result[:not_modified] && existing
+            @mutex.synchronize { existing.fetched_at = now }
+            existing.jwks
+          else
+            jwks = JWKSet.import(result[:body])
+            @mutex.synchronize do
+              @cache[url] = CacheEntry.new(jwks, result[:etag], now)
+            end
+            jwks
+          end
+        end
+
+        # Drop all cached entries.
+        # @return [void]
+        def clear
+          @mutex.synchronize { @cache.clear }
+        end
+
+        # @api private
+        def cached?(url)
+          @mutex.synchronize { @cache.key?(url) }
+        end
+
+        private
+
+        def validate_uri!(url, allow_http:)
+          uri = URI.parse(url)
+          raise JWKSFetchError, "Invalid URL: #{url.inspect} (expected http/https)" unless uri.is_a?(URI::HTTP)
+
+          if uri.scheme == "http" && !allow_http
+            raise JWKSFetchError,
+                  "Refusing non-HTTPS URL #{url.inspect} (pass allow_http: true to override)"
+          end
+          uri
+        rescue URI::InvalidURIError => e
+          raise JWKSFetchError, "Invalid URL: #{e.message}"
+        end
+
+        def fresh_entry(url, cache_ttl)
+          @mutex.synchronize do
+            entry = @cache[url]
+            return nil unless entry
+            return entry if (now - entry.fetched_at) < cache_ttl
+
+            nil
+          end
+        end
+
+        def do_http_get(uri, etag, timeout, open_timeout, max_body_bytes)
+          response = perform_request(uri, etag, timeout, open_timeout)
+          handle_response(response, max_body_bytes)
+        rescue Net::OpenTimeout, Net::ReadTimeout => e
+          raise JWKSFetchError, "Timeout fetching JWKS from #{uri}: #{e.message}"
+        rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH,
+               Errno::ENETUNREACH, OpenSSL::SSL::SSLError => e
+          raise JWKSFetchError, "Network error fetching JWKS from #{uri}: #{e.message}"
+        end
+
+        # :nocov: — real HTTP path; unit tests stub this method.
+        def perform_request(uri, etag, timeout, open_timeout)
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = (uri.scheme == "https")
+          http.read_timeout = timeout
+          http.open_timeout = open_timeout
+
+          req = Net::HTTP::Get.new(uri.request_uri)
+          req["Accept"] = "application/jwk-set+json, application/json"
+          req["If-None-Match"] = etag if etag
+
+          http.request(req)
+        end
+        # :nocov:
+
+        def handle_response(response, max_body_bytes)
+          case response
+          when Net::HTTPNotModified
+            { not_modified: true }
+          when Net::HTTPSuccess
+            validate_body_size!(response, max_body_bytes)
+            { not_modified: false, body: response.body, etag: response["ETag"] }
+          when Net::HTTPRedirection
+            raise JWKSFetchError,
+                  "Refusing to follow redirect to #{response["Location"].inspect}"
+          else
+            raise JWKSFetchError, "HTTP #{response.code} #{response.message}"
+          end
+        end
+
+        def validate_body_size!(response, max_body_bytes)
+          declared = response["Content-Length"]&.to_i
+          if declared && declared > max_body_bytes
+            raise JWKSFetchError,
+                  "JWKS body too large: Content-Length #{declared} > #{max_body_bytes}"
+          end
+
+          actual = response.body&.bytesize || 0
+          return unless actual > max_body_bytes
+
+          raise JWKSFetchError,
+                "JWKS body too large: #{actual} bytes > #{max_body_bytes}"
+        end
+
+        def now
+          Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i
+        end
+      end
+    end
+  end
+end

--- a/spec/jwt/pq/jwks_loader_spec.rb
+++ b/spec/jwt/pq/jwks_loader_spec.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+require "net/http"
+
+RSpec.describe JWT::PQ::JWKSet::Loader do
+  let(:url) { "https://issuer.example/.well-known/jwks.json" }
+  let(:key) { JWT::PQ::Key.generate(:ml_dsa_65) }
+  let(:jwks_json) { JWT::PQ::JWKSet.new([key]).to_json }
+  let(:loader) { described_class.new }
+
+  def build_response(klass, code, message, body: nil, headers: {})
+    resp = klass.new("1.1", code, message)
+    resp.instance_variable_set(:@body, body) if body
+    resp.instance_variable_set(:@read, true)
+    headers.each { |k, v| resp[k] = v }
+    resp
+  end
+
+  def ok(body:, headers: {})
+    build_response(Net::HTTPOK, "200", "OK", body: body, headers: headers)
+  end
+
+  def not_modified
+    build_response(Net::HTTPNotModified, "304", "Not Modified")
+  end
+
+  def redirect(location:)
+    build_response(Net::HTTPFound, "302", "Found", headers: { "Location" => location })
+  end
+
+  def server_error
+    build_response(Net::HTTPInternalServerError, "500", "Internal Server Error")
+  end
+
+  def stub_http(response)
+    allow(loader).to receive(:perform_request).and_return(response)
+  end
+
+  describe "#fetch on first hit" do
+    before { stub_http(ok(body: jwks_json)) }
+
+    it "returns a parsed JWKSet" do
+      result = loader.fetch(url)
+      expect(result).to be_a(JWT::PQ::JWKSet)
+      expect(result.size).to eq(1)
+    end
+
+    it "looks up by kid using the original key's thumbprint" do
+      result = loader.fetch(url)
+      expect(result[key.jwk_thumbprint]).not_to be_nil
+    end
+
+    it "populates the cache" do
+      loader.fetch(url)
+      expect(loader.cached?(url)).to be(true)
+    end
+
+    it "sends no If-None-Match header on the first request" do
+      loader.fetch(url)
+      expect(loader).to have_received(:perform_request).with(anything, nil, anything, anything)
+    end
+  end
+
+  describe "cache behaviour" do
+    it "returns the cached set without hitting HTTP within the TTL" do
+      stub_http(ok(body: jwks_json))
+      first = loader.fetch(url, cache_ttl: 300)
+      second = loader.fetch(url, cache_ttl: 300)
+      expect(loader).to have_received(:perform_request).once
+      expect(second).to equal(first)
+    end
+
+    it "re-fetches after the TTL expires, forwarding the stored ETag" do
+      stub_http(ok(body: jwks_json, headers: { "ETag" => '"v1"' }))
+      loader.fetch(url, cache_ttl: 0)
+      loader.fetch(url, cache_ttl: 0)
+
+      expect(loader).to have_received(:perform_request).with(anything, '"v1"', anything, anything)
+    end
+
+    it "reuses the cached JWKSet on a 304 Not Modified response" do
+      stub_http(ok(body: jwks_json, headers: { "ETag" => '"v1"' }))
+      first = loader.fetch(url, cache_ttl: 0)
+
+      stub_http(not_modified)
+      second = loader.fetch(url, cache_ttl: 0)
+
+      expect(second).to equal(first)
+    end
+
+    it "#clear drops all cached entries" do
+      stub_http(ok(body: jwks_json))
+      loader.fetch(url)
+      loader.clear
+      expect(loader.cached?(url)).to be(false)
+    end
+  end
+
+  describe "URL validation" do
+    it "rejects non-HTTP schemes" do
+      expect { loader.fetch("ftp://issuer.example/jwks.json") }
+        .to raise_error(JWT::PQ::JWKSFetchError, /Invalid URL/)
+    end
+
+    it "rejects plain http:// by default" do
+      expect { loader.fetch("http://issuer.example/jwks.json") }
+        .to raise_error(JWT::PQ::JWKSFetchError, /non-HTTPS/)
+    end
+
+    it "allows plain http:// when allow_http: true" do
+      stub_http(ok(body: jwks_json))
+      expect { loader.fetch("http://issuer.example/jwks.json", allow_http: true) }
+        .not_to raise_error
+    end
+
+    it "rejects a syntactically invalid URL" do
+      expect { loader.fetch("not a url") }
+        .to raise_error(JWT::PQ::JWKSFetchError, /Invalid URL/)
+    end
+  end
+
+  describe "response handling" do
+    it "refuses to follow redirects" do
+      stub_http(redirect(location: "https://elsewhere.example/jwks.json"))
+      expect { loader.fetch(url) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /Refusing to follow redirect/)
+    end
+
+    it "raises on non-2xx responses" do
+      stub_http(server_error)
+      expect { loader.fetch(url) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /HTTP 500/)
+    end
+
+    it "surfaces malformed JWKS bodies as KeyError" do
+      stub_http(ok(body: '{"keys":"nope"}'))
+      expect { loader.fetch(url) }
+        .to raise_error(JWT::PQ::KeyError)
+    end
+  end
+
+  describe "body size enforcement" do
+    it "rejects a response whose Content-Length exceeds the cap" do
+      stub_http(ok(body: jwks_json, headers: { "Content-Length" => "10000000" }))
+      expect { loader.fetch(url, max_body_bytes: 1024) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /Content-Length/)
+    end
+
+    it "rejects an oversized body even without Content-Length" do
+      stub_http(ok(body: "x" * 2048))
+      expect { loader.fetch(url, max_body_bytes: 1024) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /body too large/)
+    end
+  end
+
+  describe "network errors" do
+    it "wraps Net::OpenTimeout in JWKSFetchError" do
+      allow(loader).to receive(:perform_request).and_raise(Net::OpenTimeout.new("connect timed out"))
+      expect { loader.fetch(url) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /Timeout/)
+    end
+
+    it "wraps Net::ReadTimeout in JWKSFetchError" do
+      allow(loader).to receive(:perform_request).and_raise(Net::ReadTimeout.new("read timed out"))
+      expect { loader.fetch(url) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /Timeout/)
+    end
+
+    it "wraps SocketError in JWKSFetchError" do
+      allow(loader).to receive(:perform_request).and_raise(SocketError.new("DNS failure"))
+      expect { loader.fetch(url) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /Network error/)
+    end
+
+    it "wraps Errno::ECONNREFUSED in JWKSFetchError" do
+      allow(loader).to receive(:perform_request).and_raise(Errno::ECONNREFUSED)
+      expect { loader.fetch(url) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /Network error/)
+    end
+
+    it "wraps OpenSSL::SSL::SSLError in JWKSFetchError" do
+      allow(loader).to receive(:perform_request).and_raise(OpenSSL::SSL::SSLError.new("bad cert"))
+      expect { loader.fetch(url) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /Network error/)
+    end
+  end
+
+  describe ".default" do
+    after { described_class.reset_default! }
+
+    it "returns a process-global singleton" do
+      expect(described_class.default).to equal(described_class.default)
+    end
+
+    it "reset_default! clears the singleton" do
+      first = described_class.default
+      described_class.reset_default!
+      expect(described_class.default).not_to equal(first)
+    end
+  end
+
+  describe "JWT::PQ::JWKSet.fetch" do
+    after { described_class.reset_default! }
+
+    it "delegates to the default loader" do
+      allow(described_class.default).to receive(:fetch).with(url, cache_ttl: 60).and_return(:ok)
+      expect(JWT::PQ::JWKSet.fetch(url, cache_ttl: 60)).to eq(:ok)
+      expect(described_class.default).to have_received(:fetch).with(url, cache_ttl: 60)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `JWT::PQ::JWKSet.fetch(url, ...)` for pulling a JWKS document
from a remote endpoint (e.g. `/.well-known/jwks.json` on an identity
provider) and caching the parsed set per URL. Closes the consumer-side
gap that `ruby-jwt` intentionally leaves to the application layer.

## API

```ruby
jwks = JWT::PQ::JWKSet.fetch("https://issuer.example/.well-known/jwks.json")

_payload, header = JWT.decode(token, nil, false)
key = jwks[header["kid"]] or raise "unknown kid"
payload, = JWT.decode(token, key, true, algorithms: [header["alg"]])
```

**Options** (all kwargs, with sensible defaults):

```ruby
JWT::PQ::JWKSet.fetch(url,
  cache_ttl: 300,         # seconds the cached set is considered fresh
  timeout: 5,             # read timeout
  open_timeout: 5,        # connect timeout
  max_body_bytes: 1_048_576, # 1 MB cap on response body
  allow_http: false)      # reject plain http:// by default
```

## Design

- **Process-global cache**, keyed by URL, Mutex-guarded. Repeated calls
  inside `cache_ttl` return without hitting the network.
- **ETag revalidation**: once TTL expires, next call issues a
  conditional GET with `If-None-Match`; `304 Not Modified` refreshes
  the timestamp without re-parsing.
- **Stdlib-only** (`Net::HTTP` + `URI`). No new runtime deps.

## Defense-in-depth defaults

- HTTPS only (pass `allow_http: true` for dev).
- Redirects rejected — update the URL to the canonical location.
- Response body capped at 1 MB (ML-DSA pubkeys are 1.3–2.6 KB each,
  so 1 MB allows hundreds of rotation candidates).
- 5 s read/open timeouts.
- Network/HTTP failures raise `JWT::PQ::JWKSFetchError` (new error).
- Malformed bodies still surface as `JWT::PQ::KeyError` from `JWKSet.import`.

## Files

- `lib/jwt/pq/jwks_loader.rb` — `Loader` class (new)
- `lib/jwt/pq/jwk_set.rb` — `.fetch` shortcut delegating to `Loader.default`
- `lib/jwt/pq/errors.rb` — `JWKSFetchError` added to the hierarchy
- `README.md` — new "Fetching a remote JWKS" section

## Test plan

- [x] 25 new specs cover cache hits/misses, ETag revalidation, 304 handling, URL validation (HTTPS enforcement, redirect rejection, bad schemes), body size enforcement (Content-Length + actual bytes), and wrapping of network errors (`Net::OpenTimeout`, `Net::ReadTimeout`, `SocketError`, `ECONNREFUSED`, `OpenSSL::SSL::SSLError`).
- [x] `bundle exec rspec` — 288 examples, 0 failures, **100.0% line coverage**, 89.55% branch.
- [x] `bundle exec rubocop` — no offenses.
- [x] `bundle exec yard doc --fail-on-warning` — clean build.
- [x] README updated with fetch example and full option reference.

## Notes

- Tests stub the private `perform_request` seam; the real `Net::HTTP` call itself is marked `:nocov:` since it can't be unit-tested without spinning up a TCP server. Integration test against a real server could be added later.
- Stacks on top of #23 (fuzz-driven import hardening). If #23 lands first I'll rebase; otherwise they're independent and either merge order works.