### PR TITLE
fix(key): thread-safe sign/verify/destroy! via per-instance mutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,11 @@ Because `draft-ietf-cose-dilithium` is still pre-RFC, the JWK `kty`/`alg` values
 
 ## Thread safety
 
-- `JWT::PQ::Key` and `JWT::PQ::HybridKey` are safe to share across threads for **verification**. The underlying `OQS_SIG` verify context is process-global and reused; verify itself is stateless at the liboqs level.
-- **Signing** from multiple threads with the *same* `Key` instance is also safe in practice (liboqs ML-DSA sign does not mutate context state), but if you want the strongest guarantee, give each thread its own `Key` and use `destroy!` when done.
-- `destroy!` mutates the receiver — do not call it concurrently with `#sign` / `#verify`.
+`JWT::PQ::Key` and `JWT::PQ::HybridKey` are safe to share across threads for `#sign`, `#verify`, `#destroy!`, and `Key#private_to_pem` (hybrid sign also covers the Ed25519 + ML-DSA compound atomically). Each instance carries its own mutex that serializes those operations against each other, so a concurrent `#destroy!` waits for any in-flight signing/verification/PEM export to finish before zeroing the private key material. Read-only exporters on immutable state (`#to_pem`, `#public_key`, `#algorithm`, `#jwk_thumbprint`) do not take the mutex.
+
+The mutex cost is negligible against ML-DSA signing latency (~130–200 µs): single-threaded ML-DSA-65 throughput stays within run-to-run noise of the pre-mutex baseline (~7300 sigs/s on an i9-9880H). Under MRI the GVL already serializes signing within a single process; the mutex exists to guarantee atomicity against `destroy!`, not to extract parallelism.
+
+**Fork caveat.** A Mutex held by a live thread at `fork(2)` time is inherited locked-with-no-owner in the child. If you fork workers (Puma, Unicorn, Resque, etc.), do so before any thread begins signing on a shared `Key`, or let each worker construct its own keys post-fork. Do not call `destroy!` on a parent-side key and then fork.
 
 ## Algorithm registration
 

--- a/lib/jwt/pq.rb
+++ b/lib/jwt/pq.rb
@@ -41,5 +41,23 @@ module JWT
     rescue LoadError
       false
     end
+
+    # Drop the cache of liboqs signature handles held by this process.
+    #
+    # Call from a post-fork hook in clustered Rack/Rails servers so
+    # that child workers allocate fresh FFI handles instead of reusing
+    # pointers inherited from the parent via copy-on-write. The first
+    # sign/verify call in the child will lazily rebuild the handle.
+    #
+    # @example Puma (config/puma.rb)
+    #   on_worker_boot { JWT::PQ.reset_handles! }
+    #
+    # @example Unicorn
+    #   after_fork { |_server, _worker| JWT::PQ.reset_handles! }
+    #
+    # @return [void]
+    def self.reset_handles!
+      MlDsa.reset_handles!
+    end
   end
 end

--- a/lib/jwt/pq/algorithms/hybrid_eddsa.rb
+++ b/lib/jwt/pq/algorithms/hybrid_eddsa.rb
@@ -39,11 +39,11 @@ module JWT
           end
           raise_sign_error!("Both Ed25519 and ML-DSA private keys required") unless signing_key.private?
 
-          ed_sig = signing_key.ed25519_signing_key.sign(data)
-          ml_sig = signing_key.ml_dsa_key.sign(data)
-
-          # Concatenate: Ed25519 (64 bytes) || ML-DSA (variable)
-          ed_sig + ml_sig
+          # Delegate to HybridKey#sign so the Ed25519 and ML-DSA halves
+          # are taken atomically under the hybrid key's mutex — a
+          # concurrent destroy! can no longer slip between the two
+          # component signatures.
+          signing_key.sign(data)
         end
 
         def verify(data:, signature:, verification_key:)

--- a/lib/jwt/pq/hybrid_key.rb
+++ b/lib/jwt/pq/hybrid_key.rb
@@ -47,6 +47,7 @@ module JWT
         require_eddsa_dependency!
 
         @ml_dsa_key = ml_dsa
+        @op_mutex = Mutex.new
 
         case ed25519
         when Ed25519::SigningKey
@@ -95,18 +96,51 @@ module JWT
         "EdDSA+#{@ml_dsa_key.algorithm}"
       end
 
+      # Produce a hybrid signature (Ed25519 ‖ ML-DSA) over `data`.
+      #
+      # Thread-safe: both component signatures are taken under the hybrid
+      # key's own mutex, and {#destroy!} contends on the same mutex. That
+      # guarantees a concurrent `destroy!` cannot zero the Ed25519 seed
+      # while libsodium is mid-sign, and cannot produce a half-signed
+      # output (Ed25519 succeeds, ML-DSA fails because the buffer was
+      # just zeroed). Lock order is hybrid mutex → ML-DSA mutex; callers
+      # must not invoke any Key method while holding another lock that
+      # might be taken by `destroy!`.
+      #
+      # @param data [String] message bytes to sign.
+      # @return [String] concatenated signature — 64 bytes of Ed25519
+      #   followed by the ML-DSA signature.
+      # @raise [KeyError] if either half is missing its private component.
+      def sign(data)
+        @op_mutex.synchronize do
+          raise KeyError, "Ed25519 private key not available — cannot sign" unless @ed25519_signing_key
+
+          ed_sig = @ed25519_signing_key.sign(data)
+          ml_sig = @ml_dsa_key.sign(data)
+          ed_sig + ml_sig
+        end
+      end
+
       # Zero and discard private key material from both halves.
       #
       # After calling this, {#private?} becomes false and the key can only
       # be used for verification. Idempotent — safe on verification-only keys.
       #
+      # Thread-safe: serialized on the hybrid key's own mutex (which also
+      # guards {#sign}) and internally delegates to
+      # {JWT::PQ::Key#destroy!}, which uses its own mutex. A concurrent
+      # {#sign} will block until `destroy!` completes and then raise
+      # `KeyError`, never observing a half-destroyed state.
+      #
       # @return [true]
       def destroy!
-        @ml_dsa_key.destroy!
-        if @ed25519_signing_key
-          seed = @ed25519_signing_key.to_bytes
-          seed.replace("\0" * seed.bytesize)
-          @ed25519_signing_key = nil
+        @op_mutex.synchronize do
+          @ml_dsa_key.destroy!
+          if @ed25519_signing_key
+            seed = @ed25519_signing_key.to_bytes
+            seed.replace("\0" * seed.bytesize)
+            @ed25519_signing_key = nil
+          end
         end
         true
       end

--- a/lib/jwt/pq/key.rb
+++ b/lib/jwt/pq/key.rb
@@ -65,8 +65,10 @@ module JWT
         @ml_dsa = MlDsa.new(@algorithm)
         @public_key = public_key
         @private_key = private_key
+        @op_mutex = Mutex.new
 
         validate!
+        init_ffi_buffers!
       end
 
       # Generate a new keypair for the given algorithm.
@@ -94,23 +96,35 @@ module JWT
 
       # Sign data using the private key.
       #
+      # Thread-safe: serialized on a per-instance mutex shared with
+      # {#verify} and {#destroy!}, so a concurrent `destroy!` cannot race
+      # with an in-flight sign. The mutex cost (~hundreds of ns) is
+      # negligible relative to ML-DSA signing (~130–200 µs).
+      #
       # @param data [String] message bytes to sign.
       # @return [String] raw signature bytes.
       # @raise [KeyError] if this key has no private component.
       # @raise [SignatureError] if liboqs reports a signing failure.
       def sign(data)
-        raise KeyError, "Private key not available — cannot sign" unless @private_key
+        @op_mutex.synchronize do
+          raise KeyError, "Private key not available — cannot sign" unless @sk_buffer
 
-        @ml_dsa.sign_with_sk_buffer(data, sk_buffer)
+          @ml_dsa.sign_with_sk_buffer(data, @sk_buffer)
+        end
       end
 
       # Verify a signature against data using the public key.
+      #
+      # Thread-safe: serialized on a per-instance mutex shared with
+      # {#sign} and {#destroy!}.
       #
       # @param data [String] message bytes that were signed.
       # @param signature [String] raw signature bytes produced by {#sign}.
       # @return [Boolean] true if the signature is valid, false otherwise.
       def verify(data, signature)
-        @ml_dsa.verify_with_pk_buffer(data, signature, pk_buffer)
+        @op_mutex.synchronize do
+          @ml_dsa.verify_with_pk_buffer(data, signature, @pk_buffer)
+        end
       end
 
       # @return [Boolean] true when this key has a private component and can sign.
@@ -124,14 +138,20 @@ module JWT
       # be used for verification. Idempotent — safe to call multiple times,
       # and on verification-only keys.
       #
+      # Thread-safe: serialized on a per-instance mutex shared with
+      # {#sign} and {#verify}, so `destroy!` waits for any in-flight
+      # signing or verification to complete before zeroing the buffer.
+      #
       # @return [true]
       def destroy!
-        if @private_key
-          @private_key.replace("\0" * @private_key.bytesize)
-          @private_key = nil
+        @op_mutex.synchronize do
+          if @private_key
+            @private_key.replace("\0" * @private_key.bytesize)
+            @private_key = nil
+          end
+          @sk_buffer&.clear
+          @sk_buffer = nil
         end
-        @sk_buffer&.clear
-        @sk_buffer = nil
         true
       end
 
@@ -224,14 +244,20 @@ module JWT
       # The PEM carries both the private key and the public key (so the pair
       # can later be re-imported with {.from_pem} alone).
       #
+      # Thread-safe: the read of `@private_key` and the DER build are
+      # serialized against {#destroy!} on the per-instance mutex, so a
+      # concurrent `destroy!` cannot zero the bytes mid-encode.
+      #
       # @return [String] a `-----BEGIN PRIVATE KEY-----` PEM document.
       # @raise [KeyError] if this key has no private component.
       def private_to_pem
-        raise KeyError, "Private key not available" unless @private_key
+        @op_mutex.synchronize do
+          raise KeyError, "Private key not available" unless @private_key
 
-        oid = ALGORITHM_OIDS[@algorithm]
-        secure_der = PqcAsn1::DER.build_pkcs8(oid, @private_key, public_key: @public_key)
-        secure_der.to_pem
+          oid = ALGORITHM_OIDS[@algorithm]
+          secure_der = PqcAsn1::DER.build_pkcs8(oid, @private_key, public_key: @public_key)
+          secure_der.to_pem
+        end
       end
 
       # @api private
@@ -266,12 +292,19 @@ module JWT
 
       private
 
-      def sk_buffer
-        @sk_buffer ||= FFI::MemoryPointer.new(:uint8, @private_key.bytesize).put_bytes(0, @private_key)
-      end
+      # Allocate and populate the FFI buffers for the public key and (when
+      # present) the private key. Done eagerly at construction time to
+      # avoid a thread-safety race on lazy initialization: `@var ||= ...`
+      # is not atomic under MRI, so two threads concurrently calling
+      # {#sign} on a fresh key could each allocate separate
+      # FFI::MemoryPointers holding a copy of the secret key; the loser's
+      # copy then lingers in memory until GC, unzeroed. Eager init makes
+      # each Key hold exactly one copy of each key buffer for its lifetime.
+      def init_ffi_buffers!
+        @pk_buffer = FFI::MemoryPointer.new(:uint8, @public_key.bytesize).put_bytes(0, @public_key)
+        return unless @private_key
 
-      def pk_buffer
-        @pk_buffer ||= FFI::MemoryPointer.new(:uint8, @public_key.bytesize).put_bytes(0, @public_key)
+        @sk_buffer = FFI::MemoryPointer.new(:uint8, @private_key.bytesize).put_bytes(0, @private_key)
       end
 
       def resolve_algorithm(algorithm)

--- a/lib/jwt/pq/ml_dsa.rb
+++ b/lib/jwt/pq/ml_dsa.rb
@@ -41,6 +41,25 @@ module JWT
         end
       end
 
+      # Drop the process-wide cache of `OQS_SIG` handles.
+      #
+      # The first call to {.sign_handle} or {.verify_handle} in a process
+      # (or after this reset) lazily allocates a fresh handle. The
+      # inherited handles in the child are not explicitly freed — doing
+      # so can confuse `malloc` bookkeeping across forked processes. The
+      # handles leak until process exit (≤3 algorithms × <1 KB each),
+      # which is negligible.
+      #
+      # Prefer the public {JWT::PQ.reset_handles!} wrapper from
+      # application code.
+      #
+      # @api private
+      # @return [void]
+      def self.reset_handles!
+        @sign_handles_mutex.synchronize { @sign_handles.clear }
+        @verify_handles_mutex.synchronize { @verify_handles.clear }
+      end
+
       attr_reader :algorithm
 
       def initialize(algorithm)

--- a/spec/jwt/pq/key_concurrency_spec.rb
+++ b/spec/jwt/pq/key_concurrency_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+RSpec.describe "JWT::PQ::Key concurrency" do
+  # Validates that per-instance mutex + eager FFI buffer init make
+  # concurrent sign/verify/destroy! on a shared key race-free: there is
+  # exactly one sk_buffer and one pk_buffer for the lifetime of the key,
+  # and destroy! is serialized against in-flight sign/verify so no thread
+  # can observe a half-destroyed buffer.
+  describe "#sign under concurrent access" do
+    let(:key) { JWT::PQ::Key.generate(:ml_dsa_65) }
+
+    it "produces verifiable signatures from 8 parallel threads" do
+      errors = []
+      errors_mutex = Mutex.new
+
+      threads = Array.new(8) do |i|
+        Thread.new do
+          message = "msg-#{i}-#{SecureRandom.hex(4)}"
+          50.times do
+            sig = key.sign(message)
+            errors_mutex.synchronize { errors << "thread #{i} sig invalid" } unless key.verify(message, sig)
+          end
+        rescue StandardError => e
+          errors_mutex.synchronize { errors << "thread #{i}: #{e.class}: #{e.message}" }
+        end
+      end
+
+      threads.each(&:join)
+      expect(errors).to be_empty
+    end
+  end
+
+  describe "#sign after destroy! — TOCTOU guard" do
+    # The per-instance mutex serializes destroy! against sign, so a
+    # racing destroy! can only take effect between sign calls — never
+    # in the middle of an FFI call where it would corrupt the in-flight
+    # signature or segfault.
+    it "raises KeyError when sk_buffer is nilled between calls" do
+      key = JWT::PQ::Key.generate(:ml_dsa_65)
+      key.destroy!
+
+      expect { key.sign("data") }.to raise_error(JWT::PQ::KeyError, /Private key not available/)
+    end
+
+    it "serializes destroy! against in-flight sign/verify" do
+      # 4 signer threads hammer the key while another thread destroys it.
+      # Each sign must either complete and produce a verifiable signature
+      # (happened-before destroy!) or raise KeyError (happened-after).
+      # Any other outcome — a corrupted signature, a segfault, or a
+      # ruby-level NoMethodError from a half-destroyed state — would
+      # indicate the mutex is not actually serializing.
+      key = JWT::PQ::Key.generate(:ml_dsa_65)
+      pub_key = JWT::PQ::Key.from_public_key(:ml_dsa_65, key.public_key)
+
+      results = Queue.new
+      ready = Queue.new
+      signers = Array.new(4) do
+        Thread.new do
+          msg = "msg-#{SecureRandom.hex(4)}"
+          ready << :started
+          100.times do
+            results << [:ok, msg, key.sign(msg)]
+          rescue JWT::PQ::KeyError
+            results << [:destroyed]
+            break
+          end
+        end
+      end
+
+      # Wait for every signer to have entered its loop before racing
+      # destroy! — avoids the "sleep 0.001 hope it's enough" flake.
+      4.times { ready.pop }
+      key.destroy!
+      signers.each(&:join)
+
+      until results.empty?
+        tag, msg, sig = results.pop
+        case tag
+        when :ok then expect(pub_key.verify(msg, sig)).to be true
+        when :destroyed then next
+        else raise "unexpected tag #{tag}"
+        end
+      end
+    end
+  end
+
+  describe "#private_to_pem under concurrent destroy!" do
+    # The PEM export reads @private_key and hands it to the DER builder.
+    # Without the mutex, a racing destroy! could zero those bytes mid-build
+    # and produce a corrupted PEM. The mutex guarantees any PEM that
+    # returns is fully formed, and any destroy!-after-start path raises
+    # KeyError on the next export attempt.
+    it "never produces a corrupted PEM when racing destroy!" do
+      10.times do
+        key = JWT::PQ::Key.generate(:ml_dsa_65)
+        pem_thread = Thread.new do
+          key.private_to_pem
+        rescue JWT::PQ::KeyError
+          :destroyed
+        end
+        destroy_thread = Thread.new { key.destroy! }
+
+        pem = pem_thread.value
+        destroy_thread.join
+
+        if pem.is_a?(String)
+          expect(pem).to match(/\A-----BEGIN PRIVATE KEY-----/)
+          expect(pem).to match(/-----END PRIVATE KEY-----\n?\z/)
+          # A fully-formed PEM must round-trip to the same algorithm and
+          # decode without an ASN.1 error — the strongest assertion that
+          # no zero-bytes leaked into the middle of the private key.
+          reimported = JWT::PQ::Key.from_pem(pem)
+          expect(reimported.algorithm).to eq("ML-DSA-65")
+        else
+          expect(pem).to eq(:destroyed)
+        end
+      end
+    end
+  end
+
+  describe "JWT::PQ::HybridKey concurrency" do
+    before { skip "ed25519 gem not available" unless defined?(Ed25519) }
+
+    # Hybrid sign is a compound operation (Ed25519 then ML-DSA). Without
+    # a mutex on HybridKey, destroy! could run between the two component
+    # signs, yielding a half-signed failure. With the mutex, either the
+    # hybrid signature is fully formed or the entire call raises.
+    it "serializes hybrid sign against destroy!" do
+      key = JWT::PQ::HybridKey.generate(:ml_dsa_65)
+      ed_verify_key = key.ed25519_verify_key
+      ml_pub = JWT::PQ::Key.from_public_key(:ml_dsa_65, key.ml_dsa_key.public_key)
+
+      results = Queue.new
+      ready = Queue.new
+      signers = Array.new(4) do
+        Thread.new do
+          msg = "msg-#{SecureRandom.hex(4)}"
+          ready << :started
+          50.times do
+            sig = key.sign(msg)
+            results << [:ok, msg, sig]
+          rescue JWT::PQ::KeyError
+            results << [:destroyed]
+            break
+          end
+        end
+      end
+
+      4.times { ready.pop }
+      key.destroy!
+      signers.each(&:join)
+
+      until results.empty?
+        tag, msg, sig = results.pop
+        case tag
+        when :ok
+          # Any returned signature must be fully formed and verifiable
+          # on BOTH halves — the whole point of the mutex is that no
+          # "half-signed" output can leak out of HybridKey#sign.
+          ed_sig = sig.byteslice(0, 64)
+          ml_sig = sig.byteslice(64..)
+          expect { ed_verify_key.verify(ed_sig, msg) }.not_to raise_error
+          expect(ml_pub.verify(msg, ml_sig)).to be true
+        when :destroyed
+          next
+        else raise "unexpected tag #{tag}"
+        end
+      end
+    end
+  end
+
+  describe "MlDsa.reset_handles!" do
+    it "clears cached handles and the next call rebuilds them" do
+      JWT::PQ::MlDsa.sign_handle("ML-DSA-65") # warm cache
+      JWT::PQ::MlDsa.reset_handles!
+
+      # Rebuild works
+      expect(JWT::PQ::MlDsa.sign_handle("ML-DSA-65")).not_to be_null
+    end
+
+    it "is exposed at the public module level" do
+      expect(JWT::PQ).to respond_to(:reset_handles!)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Addresses three concurrency findings from the v0.4.0 code review (`jwt-pq-0.4.0-review.md`), plus two HIGH findings surfaced during a second security review.

### Original review
- **B1** (blocker) — `Key#sk_buffer` / `#pk_buffer` used `||=` for lazy init. Under MRI the reference write is atomic, but allocate-and-populate is not: two threads calling `sign` on a fresh key could each allocate a separate `FFI::MemoryPointer` holding a copy of the secret key; the loser's copy lingered unzeroed until GC. Fixed by eager allocation in `Key#init_ffi_buffers!` from the constructor — each key holds exactly one copy of each buffer for its lifetime.
- **B2** (blocker) — `destroy!` racing with `sign`/`verify`. Original plan was to document the contract with a YARD `@note`; security review pushed for real safety. `Key` and `HybridKey` now each carry an `@op_mutex` that serializes `#sign`, `#verify`, `#destroy!`, and `Key#private_to_pem`. A racing `destroy!` waits for any in-flight signing/verification/PEM export to complete before zeroing the private material; a signer that loses the race gets a clean `KeyError` instead of a corrupted signature or use-after-free in liboqs.
- **N10** (nit) — new `JWT::PQ.reset_handles!` (delegating to `@api private` `MlDsa.reset_handles!`) drops the process-wide `OQS_SIG` handle cache, so clustered Rack/Rails servers can call it from post-fork hooks instead of reusing FFI pointers inherited via COW. Zero overhead on the happy path.

### Added during security re-review
- **HybridKey compound-sign race** (HIGH) — hybrid sign is Ed25519 then ML-DSA. Without an atomic wrapper, `destroy!` could land between the two component signs (producing a half-signed failure), or worse — zero the Ed25519 seed String while libsodium was reading it in C. New `HybridKey#sign` takes both component signatures under the hybrid mutex; the algorithm class in `lib/jwt/pq/algorithms/hybrid_eddsa.rb` now delegates to it. Lock order hybrid → ML-DSA is consistent across `sign` and `destroy!`.
- **`Key#private_to_pem` unguarded read** (HIGH) — read `@private_key` and handed it to the DER builder outside any mutex; a racing `destroy!` could zero the bytes mid-encode and produce a corrupt PEM. Now wrapped in `@op_mutex.synchronize`.

### README
Thread-safety section rewritten to describe the actual protected surface (sign, verify, destroy!, private_to_pem, hybrid sign) and to call out the fork caveat: a Mutex held by a live thread at `fork(2)` time is inherited locked-with-no-owner in the child, so keys must not be mid-operation when a server forks workers.

## Benchmark

`bundle exec ruby bench/sign_throughput.rb` on ML-DSA-65, i9-9880H:

| State | sigs/s |
|---|---|
| Pre-refactor baseline | ~6850 |
| Eager buffer + TOCTOU local-capture (intermediate) | ~7500 |
| **+ per-instance mutex (this PR)** | **~7300** |

Mutex cost is within run-to-run noise of the intermediate state — under the GVL, signing is already serialized at the Ruby level, so the mutex engages meaningfully only when `destroy!` contends.

## Test plan

- [x] `bundle exec rspec` — 270 examples, 0 failures
  - 8 threads × 50 iterations of sign+verify on a shared key, all signatures round-trip
  - `destroy!` racing 4 signer threads — every returned signature is verifiable, every post-destroy sign raises `KeyError`
  - `private_to_pem` racing `destroy!` — returned PEMs are structurally intact and round-trip via `Key.from_pem`
  - `HybridKey#sign` racing `destroy!` — each returned signature has both halves verifiable (no half-signed outputs)
  - `reset_handles!` rebuilds cached handles and is exposed on `JWT::PQ`
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec yard doc --fail-on-warning` — clean
- [x] Line coverage: 99.77%