### PR TITLE
fix(hybrid): remove short-circuit in EdDSA+ML-DSA verify combinator

### DIFF
--- a/lib/jwt/pq/algorithms/hybrid_eddsa.rb
+++ b/lib/jwt/pq/algorithms/hybrid_eddsa.rb
@@ -58,20 +58,32 @@ module JWT
           ed_sig = signature.byteslice(0, ED25519_SIG_SIZE)
           ml_sig = signature.byteslice(ED25519_SIG_SIZE..)
 
-          ed_valid = begin
-            verification_key.ed25519_verify_key.verify(ed_sig, data)
-            true
-          rescue Ed25519::VerifyError
-            false
-          end
-
+          ed_valid = safe_ed25519_verify(verification_key.ed25519_verify_key, ed_sig, data)
           ml_valid = verification_key.ml_dsa_key.verify(data, ml_sig)
 
-          ed_valid && ml_valid
+          # Bitwise `&`, not `&&`: both checks are already computed above,
+          # and a bitwise AND over booleans has no short-circuit, so the
+          # final combinator does not branch on which half failed. This
+          # does not give a cryptographic constant-time guarantee (Ruby
+          # can't), but it removes the obvious observable path.
+          ed_valid & ml_valid
         # :nocov: — defensive rescue; Key#verify returns bool, does not raise PQ::Error in practice
         rescue JWT::PQ::Error
           false
           # :nocov:
+        end
+
+        # Boolean-returning wrapper over `Ed25519::VerifyKey#verify`, which
+        # raises on failure. Gives the verify path a uniform shape for both
+        # halves (both produce a bool by assignment, rather than one via
+        # return value and one via rescue).
+        #
+        # @api private
+        def safe_ed25519_verify(verify_key, signature, data)
+          verify_key.verify(signature, data)
+          true
+        rescue Ed25519::VerifyError
+          false
         end
 
         register_algorithm(new("EdDSA+ML-DSA-44"))


### PR DESCRIPTION
## Summary

Addresses **I3** from `jwt-pq-0.4.0-review.md`. `HybridEdDsa#verify` already runs both halves unconditionally and joins them with `&&`. The `&&` short-circuits when `ed_valid` is false, which in principle gives an attacker a small timing signal about which half of the hybrid rejected.

- Replace `&&` with bitwise `&` over booleans — identical result, no short-circuit.
- Factor the Ed25519 rescue out into `safe_ed25519_verify` so both halves of the verify path have the same shape (boolean return via assignment, not one via return and one via rescue).

Not a cryptographic constant-time guarantee (Ruby can't give that), but removes the obvious observable path.

## Security notes

- `safe_ed25519_verify` only rescues `Ed25519::VerifyError`; `ArgumentError` (raised by `Ed25519::VerifyKey#verify` when the signature length ≠ 64) propagates. This is safe because the caller checks `signature.bytesize > ED25519_SIG_SIZE` first and then takes exactly 64 bytes via `byteslice(0, 64)`, so the length mismatch path is unreachable.
- `ed_valid` and `ml_valid` are both plain booleans (MlDsa#verify returns `status == OQS_SUCCESS`; `safe_ed25519_verify` returns literal `true`/`false`), so `&` is well-defined on them.

## Test plan

- [x] `bundle exec rspec spec/jwt/pq/algorithms/` — 54 examples, 0 failures
- [x] `bundle exec rspec` — 263 examples, 0 failures (full suite)
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec yard doc --fail-on-warning` — clean