### PR TITLE
fix(jwk): use JSON.generate in thumbprint instead of string interpolation

### DIFF
--- a/lib/jwt/pq/jwk.rb
+++ b/lib/jwt/pq/jwk.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "base64"
+require "json"
 require "openssl"
 
 module JWT
@@ -110,8 +111,14 @@ module JWT
       # @param public_key [String] raw public key bytes.
       # @return [String] base64url-encoded SHA-256 thumbprint.
       def self.compute_thumbprint(algorithm, public_key)
+        # RFC 7638 §3.2: canonical JSON over the required members in
+        # lexicographic order (alg, kty, pub), no whitespace. Using
+        # `JSON.generate` over an ordered Hash instead of string
+        # interpolation so a future algorithm or key-byte change that
+        # introduces a character needing JSON escape does not silently
+        # produce a divergent thumbprint.
         pub_b64 = ::Base64.urlsafe_encode64(public_key, padding: false)
-        canonical = "{\"alg\":\"#{algorithm}\",\"kty\":\"#{KTY}\",\"pub\":\"#{pub_b64}\"}"
+        canonical = JSON.generate({ alg: algorithm, kty: KTY, pub: pub_b64 })
         digest = OpenSSL::Digest::SHA256.digest(canonical)
         ::Base64.urlsafe_encode64(digest, padding: false)
       end


### PR DESCRIPTION
## Summary

Addresses **I4** from `jwt-pq-0.4.0-review.md`. `JWK.compute_thumbprint` built its canonical JSON via string interpolation. That works today because every current value of `alg`, `kty`, and base64url-encoded `pub` is plain ASCII with no JSON-escape-requiring characters — but the invariant is implicit, not enforced. A future algorithm name, a change in public-key representation, or any drift would silently produce a divergent thumbprint and break `kid` interop.

Switch to `JSON.generate` over an ordered Hash (`{alg, kty, pub}` — already in RFC 7638 §3.2 lexicographic order). Ruby `Hash` preserves insertion order since 1.9 and `JSON.generate` emits no whitespace by default, so the output is **byte-identical** to the hand-rolled form for every ML-DSA input in the current parameter set. Verified both by unit tests and a direct equality check:

```ruby
"{\"alg\":\"ML-DSA-65\",\"kty\":\"AKP\",\"pub\":\"abc123-_DEF\"}" ==
  JSON.generate({ alg: "ML-DSA-65", kty: "AKP", pub: "abc123-_DEF" })
# => true
```

## Test plan

- [x] `bundle exec rspec spec/jwt/pq/jwk_spec.rb spec/jwt/pq/jwk_set_spec.rb` — 79 examples, 0 failures (includes the cross-implementation RFC 7638 thumbprint test added in #18)
- [x] `bundle exec rspec` — full suite passes
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec yard doc --fail-on-warning` — clean