### PR TITLE
chore(gemspec): tighten pqc_asn1 to ~> 0.1.0 and exclude bin/ from gem

### DIFF
--- a/jwt-pq.gemspec
+++ b/jwt-pq.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
-      f.start_with?("spec/", "vendor/", ".github/", "bench/") ||
+      f.start_with?("spec/", "vendor/", ".github/", "bench/", "bin/") ||
         f.match?(/\A(?:\.git|\.rspec|\.rubocop|jwt-pq-plan)/)
     end
   end
@@ -46,5 +46,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ffi", "~> 1.15"
   spec.add_dependency "jwt", "~> 3.0"
-  spec.add_dependency "pqc_asn1", "~> 0.1"
+  # Pre-1.0 crypto dependency: tightened to `~> 0.1.0` (patch-only) so a
+  # 0.2.0 release with a potential API break does not silently upgrade.
+  # Bump manually after vetting each new minor.
+  spec.add_dependency "pqc_asn1", "~> 0.1.0"
 end


### PR DESCRIPTION
## Summary

Addresses **N11** and **N12** from `jwt-pq-0.4.0-review.md`.

- **N11** — `pqc_asn1` is pre-1.0 and sits in the PEM parse path. `~> 0.1` allows any `0.x`; a minor bump could ship an API break. Tightened to `~> 0.1.0` (patch-only) so a future `0.2.0` is an explicit maintenance step, not a silent upgrade from `bundle update`.
- **N12** — `bin/smoke.rb` is a developer smoke test, not a user-facing executable. It was being packaged into the published gem because the `spec.files` reject list did not include `bin/`. Added `bin/` to the reject list.

Verified via `gem build jwt-pq.gemspec` that the resulting `.gem` contains no `bin/` entries and CI still works — `.github/workflows/ci.yml`'s smoke job runs `ruby bin/smoke.rb` from the `actions/checkout` tree, not from the installed gem, so excluding `bin/` from the package does not break CI.

## Test plan

- [x] `gem build jwt-pq.gemspec` — succeeds; packaged file list contains `ext/` + `lib/` only, no `bin/`
- [x] `bundle exec rspec` — full suite passes
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec yard doc --fail-on-warning` — clean
- [x] Verified CI smoke job still has `bin/smoke.rb` available (from checkout, pre-`gem install`)