### PR TITLE
fix(ml_dsa): always synchronize handle cache reads

### DIFF
--- a/lib/jwt/pq/ml_dsa.rb
+++ b/lib/jwt/pq/ml_dsa.rb
@@ -17,7 +17,7 @@ module JWT
       @sign_handles_mutex = Mutex.new
 
       def self.sign_handle(algorithm)
-        @sign_handles[algorithm] || @sign_handles_mutex.synchronize do
+        @sign_handles_mutex.synchronize do
           @sign_handles[algorithm] ||= begin
             h = LibOQS.OQS_SIG_new(algorithm)
             raise LiboqsError, "Failed to initialize #{algorithm}" if h.null?
@@ -31,7 +31,7 @@ module JWT
       @verify_handles_mutex = Mutex.new
 
       def self.verify_handle(algorithm)
-        @verify_handles[algorithm] || @verify_handles_mutex.synchronize do
+        @verify_handles_mutex.synchronize do
           @verify_handles[algorithm] ||= begin
             h = LibOQS.OQS_SIG_new(algorithm)
             raise LiboqsError, "Failed to initialize #{algorithm}" if h.null?


### PR DESCRIPTION
## Summary

Remove the double-checked-lock read from `MlDsa.sign_handle` and `MlDsa.verify_handle`. The previous pattern

```ruby
@sign_handles[algorithm] || @sign_handles_mutex.synchronize do
  @sign_handles[algorithm] ||= begin
    # ...
  end
end
```

relied on MRI's GVL serializing Hash reads against concurrent writes. That behaviour is specific to MRI's implementation; JRuby and TruffleRuby do not guarantee it, and the Ruby language spec treats concurrent Hash read/write as undefined behaviour. The updated code always takes the mutex, making the cache correct under the language spec rather than just under MRI.

## Performance

Sign and verify are ~130-200us per call; an uncontended mutex acquire under the GVL is ~100ns. Expected overhead is well under 0.1%.

Local ML-DSA-65 sign benchmark on this branch:

```
METRIC algorithm=ML-DSA-65
METRIC sigs_per_sec=7611.45
METRIC us_per_sig=131.38
```

That is slightly above the recent ~7342 sigs/s baseline from PR #25, well within benchmark noise. No measurable regression.

## Test plan

- [x] `bundle exec rspec` (297 examples, 0 failures, including `spec/jwt/pq/key_concurrency_spec.rb` and `spec/jwt/pq/ml_dsa_spec.rb`)
- [x] `bundle exec rubocop` (no offenses)
- [x] `bundle exec yard doc --fail-on-warning` (clean)
- [x] `bundle exec ruby bench/sign_throughput.rb` (7611 sigs/s)