### PR TITLE
fix(keys): wipe Ed25519 keypair and auto-zero FFI buffers on GC

### DIFF
--- a/lib/jwt/pq/hybrid_key.rb
+++ b/lib/jwt/pq/hybrid_key.rb
@@ -132,6 +132,13 @@ module JWT
       # {#sign} will block until `destroy!` completes and then raise
       # `KeyError`, never observing a half-destroyed state.
       #
+      # Ed25519 wipe: `Ed25519::SigningKey` stores the private seed in two
+      # separate Strings — `@seed` (32 bytes) returned by `#to_bytes`, and
+      # `@keypair` (64 bytes = `seed || public_key`) returned by `#keypair`.
+      # Both are `attr_reader`-backed and hand out the internal String by
+      # reference, so we must zero both in place — wiping only `@seed`
+      # leaves the first 32 bytes of `@keypair` holding the seed until GC.
+      #
       # @return [true]
       def destroy!
         @op_mutex.synchronize do
@@ -139,6 +146,8 @@ module JWT
           if @ed25519_signing_key
             seed = @ed25519_signing_key.to_bytes
             seed.replace("\0" * seed.bytesize)
+            keypair = @ed25519_signing_key.keypair
+            keypair.replace("\0" * keypair.bytesize)
             @ed25519_signing_key = nil
           end
         end

--- a/lib/jwt/pq/key.rb
+++ b/lib/jwt/pq/key.rb
@@ -288,6 +288,17 @@ module JWT
         new(algorithm: alg_name, public_key: info.public_key, private_key: sk_bytes)
       end
 
+      # @api private
+      #
+      # Build a GC finalizer that zeros the given FFI buffer before it is
+      # freed. Defined at the class level so the returned proc closes over
+      # the buffer only — capturing `self` would keep the Key alive forever
+      # and the finalizer would never run. Calling `.clear` on an already
+      # zeroed buffer (after an explicit {#destroy!}) is a safe no-op.
+      private_class_method def self.finalizer_for(sk_buffer)
+        proc { sk_buffer.clear }
+      end
+
       private_class_method :resolve_algorithm, :extract_secure_bytes, :resolve_oid!, :build_from_pkcs8
 
       private
@@ -300,11 +311,18 @@ module JWT
       # FFI::MemoryPointers holding a copy of the secret key; the loser's
       # copy then lingers in memory until GC, unzeroed. Eager init makes
       # each Key hold exactly one copy of each key buffer for its lifetime.
+      #
+      # A GC finalizer zeros `@sk_buffer` before FFI releases its memory,
+      # so a forgotten {#destroy!} cannot leak secret key bytes to the
+      # allocator. {#destroy!} remains the preferred explicit path; the
+      # finalizer is a last-resort safety net. The finalizer closes over
+      # the buffer only — not `self` — so it does not pin the Key from GC.
       def init_ffi_buffers!
         @pk_buffer = FFI::MemoryPointer.new(:uint8, @public_key.bytesize).put_bytes(0, @public_key)
         return unless @private_key
 
         @sk_buffer = FFI::MemoryPointer.new(:uint8, @private_key.bytesize).put_bytes(0, @private_key)
+        ObjectSpace.define_finalizer(self, self.class.send(:finalizer_for, @sk_buffer))
       end
 
       def resolve_algorithm(algorithm)

--- a/spec/jwt/pq/hybrid_key_spec.rb
+++ b/spec/jwt/pq/hybrid_key_spec.rb
@@ -96,5 +96,34 @@ RSpec.describe JWT::PQ::HybridKey do
       )
       expect(verify_key.destroy!).to be true
     end
+
+    it "zeros the Ed25519 seed (@seed) in place" do
+      ed_sk = Ed25519::SigningKey.generate
+      hybrid = described_class.new(
+        ed25519: ed_sk,
+        ml_dsa: JWT::PQ::Key.generate(:ml_dsa_44)
+      )
+
+      hybrid.destroy!
+
+      expect(ed_sk.to_bytes).to eq("\0" * 32)
+    end
+
+    it "zeros the Ed25519 @keypair (seed || public_key) in place" do
+      ed_sk = Ed25519::SigningKey.generate
+      hybrid = described_class.new(
+        ed25519: ed_sk,
+        ml_dsa: JWT::PQ::Key.generate(:ml_dsa_44)
+      )
+      # Capture the internal keypair String before destroy so we can verify
+      # the live object (attr_reader returns the ivar by reference) got wiped.
+      keypair_ref = ed_sk.keypair
+      expect(keypair_ref.bytesize).to eq(64)
+
+      hybrid.destroy!
+
+      expect(keypair_ref).to eq("\0" * 64)
+      expect(ed_sk.keypair).to eq("\0" * 64)
+    end
   end
 end

--- a/spec/jwt/pq/key_spec.rb
+++ b/spec/jwt/pq/key_spec.rb
@@ -126,4 +126,44 @@ RSpec.describe JWT::PQ::Key do
       expect(pub_key.destroy!).to be true
     end
   end
+
+  describe ".finalizer_for (GC safety net)" do
+    it "returns a proc that zeros the given FFI buffer when called" do
+      size = 32
+      buffer = FFI::MemoryPointer.new(:uint8, size).put_bytes(0, "A" * size)
+      expect(buffer.read_bytes(size)).to eq("A" * size)
+
+      finalizer = described_class.send(:finalizer_for, buffer)
+      expect(finalizer).to be_a(Proc)
+
+      finalizer.call
+
+      expect(buffer.read_bytes(size)).to eq("\0" * size)
+    end
+
+    it "is idempotent — calling the proc on an already-zeroed buffer is a no-op" do
+      size = 16
+      buffer = FFI::MemoryPointer.new(:uint8, size).put_bytes(0, "B" * size)
+      finalizer = described_class.send(:finalizer_for, buffer)
+
+      finalizer.call
+      expect(buffer.read_bytes(size)).to eq("\0" * size)
+
+      expect { finalizer.call }.not_to raise_error
+      expect(buffer.read_bytes(size)).to eq("\0" * size)
+    end
+
+    it "exposes finalizer_for as a private class method" do
+      expect(described_class.private_methods).to include(:finalizer_for)
+      expect { described_class.finalizer_for(nil) }
+        .to raise_error(NoMethodError, /private method/)
+    end
+
+    it "does not register a finalizer on verification-only keys" do
+      full = described_class.generate(:ml_dsa_44)
+      pub_only = described_class.from_public_key(:ml_dsa_44, full.public_key)
+      # Verification-only keys have no @sk_buffer, so no finalizer is needed.
+      expect(pub_only.instance_variable_get(:@sk_buffer)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Two memory-hygiene fixes for private key material:

- **`HybridKey#destroy!` now also wipes the Ed25519 `@keypair`.** Previously only `@seed` (32 bytes) was zeroed via `SigningKey#to_bytes#replace`. `Ed25519::SigningKey` also stores `@keypair` (64 bytes = `seed || public_key`), whose first 32 bytes hold a second live copy of the seed. That String survived `destroy!` and lingered in memory until GC. Both fields are now wiped in place through the `attr_reader` accessors.
- **`Key` registers a GC finalizer that zeros `@sk_buffer` before FFI frees it.** `FFI::MemoryPointer`'s default finalizer calls `free()` without clearing first, so a forgotten `destroy!` would release private key bytes to the allocator unzeroed. The finalizer proc is produced by `Key.finalizer_for(sk_buffer)` and closes over the buffer only — never `self` — so it does not pin the `Key` from GC. `destroy!` remains the preferred explicit path; calling `.clear` on an already-zeroed buffer is a safe no-op.

Only touches Ruby-level memory hygiene. No crypto changes, no public API changes.

## Test plan

- [x] `bundle exec rspec` — 303 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [x] `bundle exec yard doc --fail-on-warning` — passes
- [x] New spec: `HybridKey#destroy!` zeros `ed_sk.to_bytes` (32-byte seed)
- [x] New spec: `HybridKey#destroy!` zeros the live `ed_sk.keypair` reference (64 bytes)
- [x] New spec: `Key.finalizer_for(buffer)` returns a `Proc` that zeros the buffer when called
- [x] New spec: finalizer is idempotent on already-zeroed buffers
- [x] New spec: verification-only keys have no `@sk_buffer` (no finalizer registered)