### PR TITLE
fix(jwks): enforce body cap during streaming read

### DIFF
--- a/lib/jwt/pq/jwks_loader.rb
+++ b/lib/jwt/pq/jwks_loader.rb
@@ -65,6 +65,12 @@ module JWT
         # Fetch the JWKS at `url`, honouring the cache if the entry is
         # still fresh.
         #
+        # **URL provenance.** The URL is used verbatim: `Loader#fetch`
+        # does not resolve DNS, inspect the target IP, or block private,
+        # link-local, or cloud-metadata addresses. Callers are responsible
+        # for ensuring the URL comes from a trusted source (e.g. a pinned
+        # issuer configuration, not untrusted user input) to avoid SSRF.
+        #
         # @param url [String] the absolute URL of the JWKS document.
         # @param cache_ttl [Integer] seconds the cached set is considered
         #   fresh. Default: 300.
@@ -141,8 +147,11 @@ module JWT
         end
 
         def do_http_get(uri, etag, timeout, open_timeout, max_body_bytes)
-          response = perform_request(uri, etag, timeout, open_timeout)
-          handle_response(response, max_body_bytes)
+          result = nil
+          perform_request(uri, etag, timeout, open_timeout) do |response|
+            result = handle_response(response, max_body_bytes)
+          end
+          result
         rescue Net::OpenTimeout, Net::ReadTimeout => e
           raise JWKSFetchError, "Timeout fetching JWKS from #{uri}: #{e.message}"
         rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH,
@@ -151,7 +160,7 @@ module JWT
         end
 
         # :nocov: — real HTTP path; unit tests stub this method.
-        def perform_request(uri, etag, timeout, open_timeout)
+        def perform_request(uri, etag, timeout, open_timeout, &)
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = (uri.scheme == "https")
           http.read_timeout = timeout
@@ -161,7 +170,7 @@ module JWT
           req["Accept"] = "application/jwk-set+json, application/json"
           req["If-None-Match"] = etag if etag
 
-          http.request(req)
+          http.request(req, &)
         end
         # :nocov:
 
@@ -170,8 +179,8 @@ module JWT
           when Net::HTTPNotModified
             { not_modified: true }
           when Net::HTTPSuccess
-            validate_body_size!(response, max_body_bytes)
-            { not_modified: false, body: response.body, etag: response["ETag"] }
+            body = read_body_with_cap!(response, max_body_bytes)
+            { not_modified: false, body: body, etag: response["ETag"] }
           when Net::HTTPRedirection
             raise JWKSFetchError,
                   "Refusing to follow redirect to #{response["Location"].inspect}"
@@ -180,18 +189,27 @@ module JWT
           end
         end
 
-        def validate_body_size!(response, max_body_bytes)
+        # Stream the response body into memory while enforcing the cap
+        # on every chunk. A server that omits `Content-Length` cannot
+        # force unbounded allocation: the accumulator is checked before
+        # and after each append, and the connection is abandoned the
+        # moment the cap is exceeded.
+        def read_body_with_cap!(response, max_body_bytes)
           declared = response["Content-Length"]&.to_i
           if declared && declared > max_body_bytes
             raise JWKSFetchError,
                   "JWKS body too large: Content-Length #{declared} > #{max_body_bytes}"
           end
 
-          actual = response.body&.bytesize || 0
-          return unless actual > max_body_bytes
-
-          raise JWKSFetchError,
-                "JWKS body too large: #{actual} bytes > #{max_body_bytes}"
+          buffer = String.new(capacity: declared || 0)
+          response.read_body do |chunk|
+            if buffer.bytesize + chunk.bytesize > max_body_bytes
+              raise JWKSFetchError,
+                    "JWKS body too large: exceeded #{max_body_bytes} bytes during streaming read"
+            end
+            buffer << chunk
+          end
+          buffer
         end
 
         def now

--- a/spec/jwt/pq/jwks_loader_spec.rb
+++ b/spec/jwt/pq/jwks_loader_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe JWT::PQ::JWKSet::Loader do
     resp.instance_variable_set(:@body, body) if body
     resp.instance_variable_set(:@read, true)
     headers.each { |k, v| resp[k] = v }
+    if body
+      resp.define_singleton_method(:read_body) do |&block|
+        block ? block.call(body) : body
+      end
+    end
     resp
   end
 
@@ -32,8 +37,10 @@ RSpec.describe JWT::PQ::JWKSet::Loader do
     build_response(Net::HTTPInternalServerError, "500", "Internal Server Error")
   end
 
+  # Stub perform_request so it yields the response to the streaming
+  # block, mirroring the real Net::HTTP block form.
   def stub_http(response)
-    allow(loader).to receive(:perform_request).and_return(response)
+    allow(loader).to receive(:perform_request).and_yield(response)
   end
 
   describe "#fetch on first hit" do
@@ -150,6 +157,31 @@ RSpec.describe JWT::PQ::JWKSet::Loader do
       stub_http(ok(body: "x" * 2048))
       expect { loader.fetch(url, max_body_bytes: 1024) }
         .to raise_error(JWT::PQ::JWKSFetchError, /body too large/)
+    end
+
+    it "enforces the cap during streaming read when Content-Length is absent" do
+      # Server without Content-Length delivers the body in chunks. The
+      # cap must trip on the boundary chunk, before the full body is
+      # buffered in memory. A post-read check would let all chunks be
+      # allocated; this spec verifies the in-stream check fires and the
+      # iterator never reaches chunks past the cap.
+      response = build_response(Net::HTTPOK, "200", "OK")
+      yielded = []
+
+      response.define_singleton_method(:read_body) do |&block|
+        4.times do |i|
+          yielded << i
+          block.call("x" * 400)
+        end
+      end
+      allow(loader).to receive(:perform_request).and_yield(response)
+
+      expect { loader.fetch(url, max_body_bytes: 1024) }
+        .to raise_error(JWT::PQ::JWKSFetchError, /exceeded 1024 bytes during streaming read/)
+
+      # Chunks 0, 1, 2 are consumed (800+400 > 1024 trips on chunk 2).
+      # Chunk 3 must never be yielded.
+      expect(yielded).to eq([0, 1, 2])
     end
   end
 


### PR DESCRIPTION
## Summary

- **Streaming body cap (DoS hardening).** `Loader#perform_request` now uses the block form of `Net::HTTP#request` and the response body is accumulated via `response.read_body` chunk-by-chunk. The per-chunk check rejects with `JWKSFetchError` the moment the accumulator would exceed `max_body_bytes`, so a server without `Content-Length` can no longer force unbounded allocation. The existing `Content-Length` pre-check is preserved for the fast path; `validate_body_size!` is folded into the new `read_body_with_cap!` helper. 304/redirect/non-2xx paths and timeout/SocketError/SSL error translations are unchanged.
- **URL provenance documentation.** `Loader#fetch`'s YARD now makes the SSRF boundary explicit: the URL is used verbatim, with no DNS resolution or IP-range filtering, so callers must source the URL from trusted configuration rather than untrusted input. No runtime change.

## Test plan

- [x] `bundle exec rspec` — 298 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [x] `bundle exec yard doc --fail-on-warning` — clean
- [x] New spec `body size enforcement / enforces the cap during streaming read when Content-Length is absent` drives the streaming path with a fake `read_body` yielding 4 chunks of 400 B against a 1024 B cap. Asserts `JWKSFetchError` is raised and, critically, that chunk index 3 is **never** yielded — proving the cap trips in-stream on the boundary chunk rather than after a full buffer.
- [x] Existing Content-Length and post-read oversize specs still pass under the streaming path.