### PR TITLE
ci: run system-libraries tests only when they're at risk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,29 +57,6 @@ jobs:
         if: matrix.ruby == '3.4' && matrix.os == 'ubuntu-latest'
         run: bundle exec yard doc --no-output --fail-on-warning
 
-  test-system-libraries:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install liboqs system-wide
-        run: |
-          sudo apt-get update && sudo apt-get install -y cmake ninja-build
-          git clone --depth 1 --branch 0.15.0 https://github.com/open-quantum-safe/liboqs
-          cd liboqs && mkdir build && cd build
-          cmake -GNinja -DBUILD_SHARED_LIBS=ON ..
-          ninja && sudo ninja install && sudo ldconfig
-
-      - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
-        with:
-          ruby-version: "3.4"
-          bundler-cache: true
-        env:
-          JWT_PQ_USE_SYSTEM_LIBRARIES: "1"
-
-      - name: Run tests
-        run: bundle exec rspec
-
   smoke:
     name: Smoke test
     runs-on: ubuntu-latest

--- a/.github/workflows/system-libraries.yml
+++ b/.github/workflows/system-libraries.yml
@@ -1,0 +1,39 @@
+name: System libraries
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "ext/**"
+      - "jwt-pq.gemspec"
+      - ".github/workflows/system-libraries.yml"
+  schedule:
+    - cron: "0 0 * * 5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-system-libraries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install liboqs system-wide
+        run: |
+          sudo apt-get update && sudo apt-get install -y cmake ninja-build
+          git clone --depth 1 --branch 0.15.0 https://github.com/open-quantum-safe/liboqs
+          cd liboqs && mkdir build && cd build
+          cmake -GNinja -DBUILD_SHARED_LIBS=ON ..
+          ninja && sudo ninja install && sudo ldconfig
+
+      - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+        env:
+          JWT_PQ_USE_SYSTEM_LIBRARIES: "1"
+
+      - name: Run tests
+        run: bundle exec rspec


### PR DESCRIPTION
## Summary

- Split `test-system-libraries` out of `ci.yml` into its own workflow (`.github/workflows/system-libraries.yml`).
- New triggers: weekly cron (Friday 00:00 UTC, matching the existing CI schedule), `workflow_dispatch`, and PRs touching `ext/**`, `jwt-pq.gemspec`, or the workflow file itself.
- Removes the ~3–5 min uncached liboqs build from every PR — the job compiles liboqs from source without a cache, so it was the long tail of CI on Ruby/spec-only changes while providing near-zero signal there.

The `--use-system-libraries` escape hatch is exercised by every merge that can plausibly break it (native build surface) plus a weekly baseline, and still manually dispatchable before a release.

## Test plan

- [x] CI green on this PR (expect `system-libraries` to **not** run — only `ext/**` / gemspec changes trigger it)
- [x] Manually dispatch `System libraries` workflow once post-merge to confirm it still passes on the new trigger