### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-04-22
+
+### Changed
+
+- Gemspec `homepage` now points to `https://jwt-pq.marcelopazzo.com` (the live verifier and docs site); `source_code_uri`, `changelog_uri`, and `bug_tracker_uri` remain on GitHub (#37)
+
 ## [0.5.0] - 2026-04-20
 
 ### Added
@@ -134,7 +140,8 @@ Throughput on Ruby 3.4.6, macOS x86_64, liboqs 0.15.0 (benchmark-ips, 2s warmup 
   - Optional dependency on jwt-eddsa / ed25519
 - Error classes: `LiboqsError`, `KeyError`, `SignatureError`, `MissingDependencyError`
 
-[Unreleased]: https://github.com/marcelopazzo/jwt-pq/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/marcelopazzo/jwt-pq/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/marcelopazzo/jwt-pq/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/marcelopazzo/jwt-pq/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/marcelopazzo/jwt-pq/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/marcelopazzo/jwt-pq/compare/v0.2.0...v0.3.0

--- a/jwt-pq.gemspec
+++ b/jwt-pq.gemspec
@@ -12,14 +12,16 @@ Gem::Specification.new do |spec|
   spec.description = "Adds ML-DSA-44, ML-DSA-65, and ML-DSA-87 post-quantum signature " \
                      "algorithms to the ruby-jwt ecosystem, with optional hybrid " \
                      "EdDSA + ML-DSA mode. Uses liboqs via FFI."
-  spec.homepage = "https://github.com/marcelopazzo/jwt-pq"
+  spec.homepage = "https://jwt-pq.marcelopazzo.com"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.2"
 
+  github_uri = "https://github.com/marcelopazzo/jwt-pq"
   spec.metadata = {
-    "source_code_uri" => spec.homepage,
-    "changelog_uri" => "#{spec.homepage}/blob/main/CHANGELOG.md",
-    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => github_uri,
+    "changelog_uri" => "#{github_uri}/blob/main/CHANGELOG.md",
+    "bug_tracker_uri" => "#{github_uri}/issues",
     "documentation_uri" => "https://rubydoc.info/gems/jwt-pq",
     "rubygems_mfa_required" => "true"
   }

--- a/lib/jwt/pq/version.rb
+++ b/lib/jwt/pq/version.rb
@@ -3,6 +3,6 @@
 module JWT
   module PQ
     # Current gem version.
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end


### PR DESCRIPTION
## Summary
- Patch release, metadata only — no code or crypto changes.
- Ships the gemspec homepage change from #37 so rubygems.org surfaces the live verifier/docs site (`https://jwt-pq.marcelopazzo.com`) as the primary link.
- `source_code_uri`, `changelog_uri`, and `bug_tracker_uri` continue to point at GitHub.

This PR is stacked on `chore/gemspec-homepage-site` (#37). Merge order options:
1. Merge #37 first, then rebase this — the diff collapses to the `version.rb` + `CHANGELOG` bumps.
2. Close #37 and merge this directly — same net effect; the gemspec change ships as part of the release commit.

After merge:
- Tag `v0.5.1` on `main`, push the tag to trigger the release workflow.

## Test plan
- [x] `bundle exec rspec` green locally (no code changed — sanity only)
- [x] `bundle exec rubocop` clean
- [x] CI green
- [ ] After merge + tag, confirm rubygems.org shows the new homepage on the 0.5.1 page