### PR TITLE
feat(jwks): tolerate unknown kty/alg in JWKSet.import for mixed rollouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `JWT::PQ::JWKSet.import` (and `JWKSet.fetch`) now tolerates mixed JWKSes: members with unknown `kty` (e.g. RSA, EC, OKP) or unsupported `alg` within `kty: "AKP"` are silently skipped instead of aborting the whole set — enabling incremental PQ rollouts where a single `/.well-known/jwks.json` carries both classical and ML-DSA keys. Pass `strict: true` to restore the previous fail-fast behaviour. Recognized-but-malformed AKP members still raise `KeyError` (#34)
+
 ## [0.5.1] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -138,6 +138,29 @@ signing: `JWT.encode(payload, key, alg, { kid: key.jwk_thumbprint })`.
 `Key#jwk_thumbprint` memoizes the digest, so it's cheap to call
 repeatedly on the same key.
 
+#### Mixed classical + PQ JWKSes
+
+`JWKSet.import` (and `JWKSet.fetch`) tolerates JWKSes that mix this
+gem's `ML-DSA-{44,65,87}` keys with classical RSA/EC/EdDSA entries or
+future PQ algorithms — members with an unknown `kty` or an
+unsupported `alg` within `kty: "AKP"` are silently dropped. This is
+the realistic shape of an incremental PQ rollout, where an issuer
+publishes both classical and ML-DSA keys on the same
+`/.well-known/jwks.json`.
+
+Members that **do** have `kty: "AKP"` with a supported `alg` but are
+otherwise malformed (missing `pub`, invalid base64url, wrong key size,
+etc.) still raise `JWT::PQ::KeyError` — that is a real bug in the
+emitter, not an interop boundary.
+
+Pass `strict: true` to restore fail-fast behaviour on any unknown
+`kty`/`alg`:
+
+```ruby
+JWT::PQ::JWKSet.import(body, strict: true)
+JWT::PQ::JWKSet.fetch(url, strict: true)
+```
+
 ### Fetching a remote JWKS
 
 For consuming a JWKS from an identity provider or sibling service,

--- a/lib/jwt/pq/jwk.rb
+++ b/lib/jwt/pq/jwk.rb
@@ -98,6 +98,27 @@ module JWT
         end
       end
 
+      # Whether a JWK hash looks like something this gem can import:
+      # a JSON object with `kty == "AKP"` and a supported ML-DSA `alg`.
+      #
+      # Used by {JWT::PQ::JWKSet.import} to tolerate mixed JWKSes during
+      # incremental PQ rollouts — a `/.well-known/jwks.json` carrying a
+      # blend of RSA/EdDSA and ML-DSA members will not raise on the
+      # classical entries. It does **not** validate the remaining fields
+      # (`pub`, `priv`, base64url-ness, key sizes); a recognized-but-
+      # malformed member still raises from {.import}, since that signals
+      # a real bug in the emitter rather than an interop boundary.
+      #
+      # @api private
+      # @param jwk_hash [Object] candidate JWK.
+      # @return [Boolean] true iff the member is in this gem's scope.
+      def self.recognized?(jwk_hash)
+        return false unless jwk_hash.is_a?(Hash)
+
+        jwk = normalize_keys(jwk_hash)
+        jwk["kty"] == KTY && ALGORITHMS.include?(jwk["alg"])
+      end
+
       # Compute the JWK Thumbprint (RFC 7638) used as `kid`.
       #
       # Delegates to {JWT::PQ::Key#jwk_thumbprint}, which memoizes the

--- a/lib/jwt/pq/jwk_set.rb
+++ b/lib/jwt/pq/jwk_set.rb
@@ -127,8 +127,20 @@ module JWT
 
       # Import a JWKS from a Hash or JSON string.
       #
-      # Each member is reconstructed via {JWT::PQ::JWK.import}; malformed
-      # members raise {KeyError}.
+      # By default, members this gem cannot represent — unknown `kty`
+      # (e.g. `RSA`, `EC`, `OKP`) or unknown `alg` within `kty: "AKP"`
+      # (e.g. a future ML-DSA parameter set or a sibling PQ algorithm not
+      # yet implemented here) — are silently dropped. This keeps the set
+      # usable during an incremental PQ rollout, where a single
+      # `/.well-known/jwks.json` carries both classical and ML-DSA keys.
+      #
+      # Members that **are** in scope (`kty: "AKP"` with a supported
+      # `alg`) but malformed — missing `pub`, wrong field type, invalid
+      # base64url, wrong key size — still raise {KeyError}: that is a
+      # real bug in the emitter, not an interop boundary.
+      #
+      # Pass `strict: true` to restore the previous fail-fast behaviour,
+      # where any unknown `kty`/`alg` raises.
       #
       # ML-DSA public keys are ~1.3–2.6 KB each, so a JWKS with N keys is
       # at least N × ~2 KB. When ingesting untrusted JWKS payloads (e.g.
@@ -138,10 +150,14 @@ module JWT
       #
       # @param source [Hash, String] a JWKS hash or JSON string with a
       #   `"keys"` array.
-      # @return [JWKSet] a new set with all parsed members.
+      # @param strict [Boolean] if true, unknown `kty`/`alg` members
+      #   raise {KeyError} instead of being skipped. Default: false.
+      # @return [JWKSet] a new set with the parsed in-scope members.
       # @raise [KeyError] if `source` is not a Hash/String, if the `keys`
-      #   field is missing or not an Array, or if any member fails to import.
-      def self.import(source)
+      #   field is missing or not an Array, if an in-scope member is
+      #   malformed, or (only when `strict: true`) if any member has an
+      #   unknown `kty`/`alg`.
+      def self.import(source, strict: false)
         hash = coerce_to_hash(source)
         raise KeyError, "Expected Hash for JWKS body, got #{hash.class}" unless hash.is_a?(Hash)
 
@@ -149,9 +165,17 @@ module JWT
         raise KeyError, "Missing 'keys' in JWKS" unless hash.key?("keys")
         raise KeyError, "'keys' must be an Array" unless hash["keys"].is_a?(Array)
 
-        members = hash["keys"].map { |jwk| JWT::PQ::JWK.import(jwk) }
+        members = hash["keys"].filter_map { |jwk| import_member(jwk, strict: strict) }
         new(members)
       end
+
+      # @api private
+      def self.import_member(jwk, strict:)
+        return nil unless strict || JWT::PQ::JWK.recognized?(jwk)
+
+        JWT::PQ::JWK.import(jwk)
+      end
+      private_class_method :import_member
 
       # @api private
       def self.coerce_to_hash(source)
@@ -183,6 +207,10 @@ module JWT
       #   _payload, header = JWT.decode(token, nil, false)
       #   key = jwks[header["kid"]] or raise "unknown kid"
       #   payload, = JWT.decode(token, key, true, algorithms: [header["alg"]])
+      #
+      # By default, members with unknown `kty`/`alg` in the fetched
+      # body are skipped (see {.import}); pass `strict: true` to make
+      # them raise.
       #
       # @param url [String] absolute JWKS URL.
       # @return [JWKSet] the parsed set of verification keys.

--- a/lib/jwt/pq/jwks_loader.rb
+++ b/lib/jwt/pq/jwks_loader.rb
@@ -80,6 +80,9 @@ module JWT
         #   Default: 1 MB.
         # @param allow_http [Boolean] allow plain `http://` URLs. Default:
         #   false (strongly recommended for production).
+        # @param strict [Boolean] forwarded to {JWKSet.import}: if true,
+        #   members with unknown `kty`/`alg` raise instead of being
+        #   skipped. Default: false.
         # @return [JWKSet] the parsed set of verification keys.
         # @raise [JWKSFetchError] on network error, timeout, non-2xx
         #   response, oversized body, redirect, or non-HTTPS URL.
@@ -89,7 +92,8 @@ module JWT
                   timeout: DEFAULT_TIMEOUT,
                   open_timeout: DEFAULT_OPEN_TIMEOUT,
                   max_body_bytes: DEFAULT_MAX_BODY_BYTES,
-                  allow_http: false)
+                  allow_http: false,
+                  strict: false)
           uri = validate_uri!(url, allow_http: allow_http)
 
           fresh = fresh_entry(url, cache_ttl)
@@ -102,7 +106,7 @@ module JWT
             @mutex.synchronize { existing.fetched_at = now }
             existing.jwks
           else
-            jwks = JWKSet.import(result[:body])
+            jwks = JWKSet.import(result[:body], strict: strict)
             @mutex.synchronize do
               @cache[url] = CacheEntry.new(jwks, result[:etag], now)
             end

--- a/spec/jwt/pq/jwk_set_spec.rb
+++ b/spec/jwt/pq/jwk_set_spec.rb
@@ -211,9 +211,71 @@ RSpec.describe JWT::PQ::JWKSet do
         .to raise_error(JWT::PQ::KeyError, /must be an Array/)
     end
 
-    it "propagates JWK-level errors from members" do
-      expect { described_class.import({ "keys" => [{ "kty" => "RSA" }] }) }
+    it "propagates JWK-level errors from in-scope but malformed members" do
+      malformed = original.export
+      malformed[:keys].first.delete(:pub)
+
+      expect { described_class.import(malformed) }
+        .to raise_error(JWT::PQ::KeyError, /pub/)
+    end
+  end
+
+  describe ".import with mixed JWKS (issue #34)" do
+    let(:rsa_jwk)   { { "kty" => "RSA", "kid" => "rsa-1", "n" => "...", "e" => "AQAB" } }
+    let(:ec_jwk)    { { "kty" => "EC", "kid" => "ec-1", "crv" => "P-256", "x" => "...", "y" => "..." } }
+    let(:okp_jwk)   { { "kty" => "OKP", "kid" => "ed-1", "crv" => "Ed25519", "x" => "..." } }
+    let(:akp_jwk_a) { JWT::PQ::JWK.new(key_a).export }
+    let(:akp_jwk_b) { JWT::PQ::JWK.new(key_b).export }
+
+    it "skips unknown kty members and keeps the AKP ones" do
+      mixed = { "keys" => [rsa_jwk, akp_jwk_a, ec_jwk, akp_jwk_b, okp_jwk] }
+      set = described_class.import(mixed)
+      expect(set.size).to eq(2)
+      expect(set[kid_a]).not_to be_nil
+      expect(set[kid_b]).not_to be_nil
+    end
+
+    it "skips unknown alg within kty: AKP (forward-compat for future PQ algs)" do
+      future_akp = { "kty" => "AKP", "alg" => "ML-DSA-99", "pub" => "...", "kid" => "future" }
+      set = described_class.import({ "keys" => [future_akp, akp_jwk_a] })
+      expect(set.size).to eq(1)
+      expect(set[kid_a]).not_to be_nil
+    end
+
+    it "skips non-Hash members silently" do
+      set = described_class.import({ "keys" => [nil, "junk", 42, akp_jwk_a] })
+      expect(set.size).to eq(1)
+    end
+
+    it "returns an empty set when no members are in scope" do
+      set = described_class.import({ "keys" => [rsa_jwk, ec_jwk, okp_jwk] })
+      expect(set).to be_empty
+    end
+
+    it "still raises for in-scope members with malformed payloads" do
+      bad_akp = akp_jwk_a.dup
+      bad_akp[:pub] = "***not-base64url***"
+
+      expect { described_class.import({ "keys" => [rsa_jwk, bad_akp] }) }
+        .to raise_error(JWT::PQ::KeyError, /base64url/)
+    end
+
+    it "strict: true restores fail-fast on unknown kty" do
+      expect { described_class.import({ "keys" => [rsa_jwk, akp_jwk_a] }, strict: true) }
         .to raise_error(JWT::PQ::KeyError, /kty/)
+    end
+
+    it "strict: true raises on unknown alg within AKP" do
+      future_akp = { "kty" => "AKP", "alg" => "ML-DSA-99", "pub" => "..." }
+      expect { described_class.import({ "keys" => [future_akp] }, strict: true) }
+        .to raise_error(JWT::PQ::KeyError, /algorithm/)
+    end
+
+    it "accepts a JSON string body with mixed keys" do
+      mixed_json = JSON.generate({ keys: [rsa_jwk, akp_jwk_a] })
+      set = described_class.import(mixed_json)
+      expect(set.size).to eq(1)
+      expect(set[kid_a]).not_to be_nil
     end
   end
 

--- a/spec/jwt/pq/jwks_loader_spec.rb
+++ b/spec/jwt/pq/jwks_loader_spec.rb
@@ -144,6 +144,30 @@ RSpec.describe JWT::PQ::JWKSet::Loader do
       expect { loader.fetch(url) }
         .to raise_error(JWT::PQ::KeyError)
     end
+
+    it "tolerates mixed classical+PQ JWKS by default (skips unknown kty)" do
+      mixed = JSON.generate(
+        keys: [
+          { kty: "RSA", kid: "rsa-1", n: "...", e: "AQAB" },
+          JWT::PQ::JWK.new(key).export
+        ]
+      )
+      stub_http(ok(body: mixed))
+
+      set = loader.fetch(url)
+      expect(set.size).to eq(1)
+      expect(set[key.jwk_thumbprint]).not_to be_nil
+    end
+
+    it "forwards strict: to JWKSet.import so unknown kty raises" do
+      mixed = JSON.generate(
+        keys: [{ kty: "RSA", kid: "rsa-1", n: "...", e: "AQAB" }, JWT::PQ::JWK.new(key).export]
+      )
+      stub_http(ok(body: mixed))
+
+      expect { loader.fetch(url, strict: true) }
+        .to raise_error(JWT::PQ::KeyError, /kty/)
+    end
   end
 
   describe "body size enforcement" do


### PR DESCRIPTION
Closes #34.

## Summary

- `JWKSet.import` (and `JWKSet.fetch`) now silently skips JWKS members with unknown `kty` (RSA/EC/OKP) or unsupported `alg` within `kty: "AKP"` (e.g. a future ML-DSA parameter set or sibling PQ algorithm). Enables incremental PQ rollouts where a single `/.well-known/jwks.json` mixes classical and ML-DSA keys.
- Recognized-but-malformed AKP members (missing `pub`, invalid base64url, wrong key size) still raise `JWT::PQ::KeyError` — that is a real emitter bug, not an interop boundary.
- New `strict:` kwarg (default `false`) on `JWKSet.import`, `JWKSet.fetch`, and `Loader#fetch` restores the previous fail-fast behaviour.
- Internal helper `JWK.recognized?` (marked `@api private`) encapsulates the kty+alg scope check.

## Behaviour matrix

| member shape | default (`strict: false`) | `strict: true` |
|---|---|---|
| `kty: "AKP"`, supported `alg`, valid | imported | imported |
| `kty: "AKP"`, supported `alg`, malformed (`pub` missing / bad b64u / wrong size) | **raises `KeyError`** | **raises `KeyError`** |
| `kty: "AKP"`, unsupported `alg` (e.g. `ML-DSA-99`) | skipped | raises `KeyError` |
| `kty: "RSA"` / `"EC"` / `"OKP"` | skipped | raises `KeyError` |
| non-Hash member (`nil`, `42`, `"junk"`) | skipped | raises `KeyError` |

## Test plan

- [x] Updated existing fail-fast test to the new contract (malformed AKP still raises).
- [x] New `describe ".import with mixed JWKS (issue #34)"` block covering: skipped RSA/EC/OKP, skipped future AKP `alg`, non-Hash members, all-out-of-scope returns empty set, malformed AKP still raises, `strict: true` for both unknown `kty` and unknown `alg`, JSON string body with mixed members.
- [x] New loader specs: default tolerates mixed body; `strict:` is forwarded through `Loader#fetch` to `JWKSet.import`.
- [x] Fuzz spec unchanged (contract was "only `KeyError` or success" — silent-skip satisfies it).
- [x] `bundle exec rspec` — 314 examples, 0 failures.
- [x] `bundle exec rubocop lib spec` — clean.
- [x] `bundle exec yard doc --fail-on-warning` — no warnings.

## Docs

- README: new **Mixed classical + PQ JWKSes** subsection under JWK Set.
- CHANGELOG: `[Unreleased] / Changed` entry.