### PR TITLE
ci: add Ruby 4.0 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ruby 4.0 officially supported (CI matrix now covers 3.2, 3.3, 3.4, and 4.0 on Linux and macOS)
+
 ## [0.5.1] - 2026-04-22
 
 ### Changed


### PR DESCRIPTION
## Summary
- Ruby 4.0 shipped (latest stable 4.0.2 at the time of this PR).
- Full rspec suite (304 examples, 0 failures, 99.81% line coverage) passes on 4.0.2 locally with the vendored liboqs 0.15.0 build on macOS.
- Rubocop clean on 4.0.2.
- Add `"4.0"` to the CI matrix (ubuntu-latest + macos-latest) so we keep continuous signal against the new major.

`required_ruby_version` in the gemspec already accepts >= 3.2 with no upper bound, so no gemspec change is needed.

## Test plan
- [x] `bundle exec rspec` — 304 passed, 0 failed, line coverage 99.81%
- [x] `bundle exec rubocop` — clean
- [x] CI green across the full 4-row × 2-OS matrix