### PR TITLE
ci(docs): publish YARD docs to GitHub Pages on tag push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Docs
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build YARD docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build
+
+      - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Build YARD docs
+        run: bundle exec yard doc --fail-on-warning
+
+      - name: Write CNAME
+        run: echo "docs.jwt-pq.marcelopazzo.com" > doc/CNAME
+
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/jwt-pq.gemspec
+++ b/jwt-pq.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => github_uri,
     "changelog_uri" => "#{github_uri}/blob/main/CHANGELOG.md",
     "bug_tracker_uri" => "#{github_uri}/issues",
-    "documentation_uri" => "https://rubydoc.info/gems/jwt-pq",
+    "documentation_uri" => "https://docs.jwt-pq.marcelopazzo.com",
     "rubygems_mfa_required" => "true"
   }
 


### PR DESCRIPTION
## Summary

- rubydoc.info has been failing to build the docs ever since 0.5.0. The gemspec now ships `spec.extensions = ["ext/jwt/pq/extconf.rb"]` which downloads and compiles liboqs from source during `gem install`, and rubydoc.info's sandbox cannot run cmake / fetch the tarball (HTTP 520 on `/gems/jwt-pq/0.5.0` and `/0.5.1`; `/gems/jwt-pq` still serves 0.4.0).
- New `Docs` workflow builds YARD with `--fail-on-warning` and deploys to GitHub Pages on `v*` tag pushes (and `workflow_dispatch`). SHA-pinned to match the rest of the workflows.
- `documentation_uri` in the gemspec now points at `https://docs.jwt-pq.marcelopazzo.com`.

## One-time setup required before this takes effect

1. DNS: `CNAME docs.jwt-pq.marcelopazzo.com -> marcelopazzo.github.io`
2. Settings → Pages → Source: **GitHub Actions**
3. After the first deploy: set the custom domain to `docs.jwt-pq.marcelopazzo.com` and enable **Enforce HTTPS** once the cert provisions.

## Test plan

- [x] Merge
- [x] Do the DNS + Pages settings above
- [x] `gh workflow run docs.yml --ref main` and watch the run
- [x] `curl -I https://docs.jwt-pq.marcelopazzo.com` returns 200 and serves the current YARD output
- [ ] Next tag push (`v*`) updates the site automatically