### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-22
+
 ### Added
 
-- Ruby 4.0 officially supported (CI matrix now covers 3.2, 3.3, 3.4, and 4.0 on Linux and macOS)
+- Ruby 4.0 officially supported (CI matrix now covers 3.2, 3.3, 3.4, and 4.0 on Linux and macOS) (#40)
+- YARD reference site: `docs.yml` workflow publishes the generated docs to GitHub Pages on every tag push, served at `docs.jwt-pq.marcelopazzo.com` (#41)
 
 ### Changed
 
-- `JWT::PQ::JWKSet.import` (and `JWKSet.fetch`) now tolerates mixed JWKSes: members with unknown `kty` (e.g. RSA, EC, OKP) or unsupported `alg` within `kty: "AKP"` are silently skipped instead of aborting the whole set — enabling incremental PQ rollouts where a single `/.well-known/jwks.json` carries both classical and ML-DSA keys. Pass `strict: true` to restore the previous fail-fast behaviour. Recognized-but-malformed AKP members still raise `KeyError` (#34)
+- `JWT::PQ::JWKSet.import` (and `JWKSet.fetch`) now tolerates mixed JWKSes: members with unknown `kty` (e.g. RSA, EC, OKP) or unsupported `alg` within `kty: "AKP"` are silently skipped instead of aborting the whole set — enabling incremental PQ rollouts where a single `/.well-known/jwks.json` carries both classical and ML-DSA keys. Pass `strict: true` to restore the previous fail-fast behaviour. Recognized-but-malformed AKP members still raise `KeyError` (#39)
 
 ## [0.5.1] - 2026-04-22
 
@@ -148,7 +151,8 @@ Throughput on Ruby 3.4.6, macOS x86_64, liboqs 0.15.0 (benchmark-ips, 2s warmup 
   - Optional dependency on jwt-eddsa / ed25519
 - Error classes: `LiboqsError`, `KeyError`, `SignatureError`, `MissingDependencyError`
 
-[Unreleased]: https://github.com/marcelopazzo/jwt-pq/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/marcelopazzo/jwt-pq/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/marcelopazzo/jwt-pq/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/marcelopazzo/jwt-pq/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/marcelopazzo/jwt-pq/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/marcelopazzo/jwt-pq/compare/v0.3.0...v0.4.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ jwt-pq is pre-1.0. Only the latest minor release receives security fixes.
 
 | Version | Supported |
 |---------|-----------|
-| 0.5.x   | Yes       |
-| < 0.5   | No        |
+| 0.6.x   | Yes       |
+| < 0.6   | No        |
 
 ## Reporting a vulnerability
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -4,9 +4,9 @@ This document records which external specifications each jwt-pq release
 targets, what its current divergences are (if any), and the compatibility
 policy for drafts in flight.
 
-## Tracked specifications — jwt-pq 0.5.x
+## Tracked specifications — jwt-pq 0.6.x
 
-Last reviewed: **2026-04-20**.
+Last reviewed: **2026-04-22**.
 
 | Spec                                                                                    | Role in jwt-pq                                                                                 | Status                      |
 |-----------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|-----------------------------|

--- a/lib/jwt/pq/version.rb
+++ b/lib/jwt/pq/version.rb
@@ -3,6 +3,6 @@
 module JWT
   module PQ
     # Current gem version.
-    VERSION = "0.5.1"
+    VERSION = "0.6.0"
   end
 end


### PR DESCRIPTION
## Summary

Bumps to **v0.6.0**, closing the `[Unreleased]` section. Minor bump motivated by:

- New API surface: `JWKSet.import` / `JWKSet.fetch` gain a `strict:` keyword and **change default behaviour** from fail-fast to skip-unknown for non-AKP / unsupported `alg` members (#39)
- Ruby 4.0 added to the CI matrix (#40)
- YARD reference site auto-publishes to GitHub Pages on tag push, served at `docs.jwt-pq.marcelopazzo.com` (#41)

Full notes in `CHANGELOG.md`.

## Files touched

- `lib/jwt/pq/version.rb` — `0.5.1 → 0.6.0`
- `CHANGELOG.md` — `[Unreleased]` closed into `[0.6.0] - 2026-04-22`, compare links updated
- `SECURITY.md` — supported versions table → `0.6.x`
- `SPEC.md` — tracked-specs heading → `0.6.x`, last-reviewed → 2026-04-22

## Test plan

- [x] `bundle exec rspec` — 314 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [ ] CI green on this PR (incl. YARD validation, Ruby 3.2/3.3/3.4/4.0 matrix, cross-impl interop)
- [ ] After merge: tag `v0.6.0` on `main` to trigger `docs.yml` and the release workflow